### PR TITLE
[BE] feat: 장바구니 상품 제거

### DIFF
--- a/docs/Cart.md
+++ b/docs/Cart.md
@@ -13,10 +13,11 @@
     -[X] 사용자가 동일 상품을 추가할 경우, "장바구니에 동일한 상품이 있습니다. 장바구니에 추가하시겠습니까?" 메세지를 리턴하고 동의한다면 old_product 가
      new_product 로 교체된다.(PUT)
 3. (DELETE) 사용자는 상품을 장바구니에 제거할 수 있다.
-    -[ ] 회원이 장바구니 상품의 삭제(버튼)을 클릭하면, 단일 CartItem을 삭제한다.
-    -[ ] request: member의 인증 정보(-> 목록 조회 때문에), cartItemId
-    -[ ] 해당 상품의 delete_status=true로 update 한다.
-    -[ ] response: 없다.
+    -[ ] 회원이 장바구니 상품의 삭제(버튼) api를 요청하면, delete_status=false인 단일 CartItem을 delete_status=true로 업데이트
+     한다.
+    -[X] request: member의 인증 정보(-> 목록 조회 때문에), cartItemId
+    -[X] 해당 상품의 delete_status=true로 update 한다.
+    -[X] response: 없다.
     -[ ] delete_status=true 인 CartItem의 장기간 보관 여부에 대해 고민해볼 것
 4. (UPDATE) 사용자는 각 상품의 구매 수량을 자유롭게 수정할 수 있다. ---> API가 필요없을지도?
     -[ ] 회원이 장바구니에 담긴 상품의 수량을 수정하고 변경(버튼)를 클릭하면 수량이 변경되도록 한다.

--- a/src/main/java/com/tutti/server/core/cart/api/CartApi.java
+++ b/src/main/java/com/tutti/server/core/cart/api/CartApi.java
@@ -7,6 +7,8 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +23,7 @@ public class CartApi implements CartApiSpec {
 
     @Override
     @GetMapping
-    public List<CartItemsResponse> getCartItems(Long memberId) {
+    public List<CartItemsResponse> getCartItems(@RequestBody Long memberId) {
         return cartService.getCartItems(memberId);
     }
 
@@ -31,5 +33,10 @@ public class CartApi implements CartApiSpec {
         cartService.addCartItem(memberId, request);
     }
 
-
+    @Override
+    @PatchMapping("/{cartItemId}")
+    public void removeCartItem(@RequestBody Long memberId,
+            @PathVariable("cartItemId") Long cartItemId) {
+        cartService.removeCartItem(memberId, cartItemId);
+    }
 }

--- a/src/main/java/com/tutti/server/core/cart/api/CartApiSpec.java
+++ b/src/main/java/com/tutti/server/core/cart/api/CartApiSpec.java
@@ -14,4 +14,7 @@ public interface CartApiSpec {
 
     @Operation(summary = "장바구니 상품 추가")
     public void addCartItem(Long memberId, CartItemRequest request);
+
+    @Operation(summary = "장바구니 상품 삭제")
+    public void removeCartItem(Long memberId, Long cartItemId);
 }

--- a/src/main/java/com/tutti/server/core/cart/application/CartService.java
+++ b/src/main/java/com/tutti/server/core/cart/application/CartService.java
@@ -11,4 +11,6 @@ public interface CartService {
     public void addCartItem(Long memberId, CartItemRequest request);
 
     public void createCartItem(Long memberId, CartItemRequest request);
+
+    public void removeCartItem(Long cartItemId, Long memberId);
 }

--- a/src/main/java/com/tutti/server/core/cart/application/CartServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/cart/application/CartServiceImpl.java
@@ -9,8 +9,10 @@ import com.tutti.server.core.support.entity.BaseEntity;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @Transactional
@@ -53,5 +55,15 @@ public class CartServiceImpl implements CartService {
 
         // 장바구니 상품 엔티티를 만들 때, 수량도 받아야 하기 때문에 파라미터로 request 가 필요하다
         cartItemRepository.save(request.toEntity(member, productItem));
+    }
+
+    @Override
+    @Transactional
+    public void removeCartItem(Long cartItemId, Long memberId) {
+        cartItemRepository.findByIdAndMemberIdAndDeleteStatusFalse(cartItemId, memberId)
+                .ifPresentOrElse(BaseEntity::delete,
+                        () -> {
+                            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "권한이 없습니다.");
+                        });
     }
 }

--- a/src/main/java/com/tutti/server/core/cart/domain/CartItem.java
+++ b/src/main/java/com/tutti/server/core/cart/domain/CartItem.java
@@ -29,7 +29,7 @@ public class CartItem extends BaseEntity {
     @JoinColumn(name = "product_item_id", nullable = false)
     private ProductItem productItem;
 
-    private String option;
+    private String productItemOption;
     private String productName;
     private String productImgUrl;
 
@@ -40,11 +40,11 @@ public class CartItem extends BaseEntity {
     private boolean soldOut;
 
     @Builder
-    public CartItem(Member member, ProductItem productItem, String option, String productName,
+    public CartItem(Member member, ProductItem productItem, String productItemOption, String productName,
             String productImgUrl, int quantity, int price, boolean soldOut) {
         this.member = member;
         this.productItem = productItem;
-        this.option = option;
+        this.productItemOption = productItemOption;
         this.productName = productName;
         this.productImgUrl = productImgUrl;
         this.quantity = quantity;

--- a/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
+++ b/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
+    Optional<CartItem> findByIdAndMemberIdAndDeleteStatusFalse(Long cartItemId, Long memberId);
+    
     Optional<CartItem> findByMemberIdAndProductItemIdAndDeleteStatusFalse(Long memberId,
             Long productItemId);
 

--- a/src/main/java/com/tutti/server/core/cart/payload/request/CartItemRequest.java
+++ b/src/main/java/com/tutti/server/core/cart/payload/request/CartItemRequest.java
@@ -23,7 +23,7 @@ public record CartItemRequest(
         return CartItem.builder()
                 .member(member)
                 .productItem(productItem)
-                .option(productItem.getOptions())
+                .productItemOption(productItem.getOptions())
                 .productName(productItem.getProduct().getName())
                 .productImgUrl(productItem.getProduct().getTitleUrl())
                 .quantity(quantity)

--- a/src/main/java/com/tutti/server/core/cart/payload/response/CartItemsResponse.java
+++ b/src/main/java/com/tutti/server/core/cart/payload/response/CartItemsResponse.java
@@ -19,7 +19,7 @@ public record CartItemsResponse(
         // 이 빌더는 CartItemsResponse 의 빌더
         return CartItemsResponse.builder()
                 .cartItemId(cartItem.getId())
-                .option(cartItem.getOption())
+                .option(cartItem.getProductItemOption())
                 .productItemName(cartItem.getProductName())
                 .productImgUrl(cartItem.getProductImgUrl())
                 .quantity(cartItem.getQuantity())


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #38 

---

### 🚀 어떤 기능을 구현했나요 ?
1. 사용자는 단일 장바구니 상품을 제거할 수 있다.
2. request: member의 인증 정보(-> 목록 조회 때문에), cartItemId
3. 해당 상품의 delete_status=true로 update 한다.

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
- 인가 구현 전으로 memberId 요청 값으로 받는 점 참고 바랍니다.
