### PR TITLE
[BE] Faq 단일 조회 기능 구현

### DIFF
--- a/src/main/java/com/tutti/server/core/config/FaqAsyncConfig.java
+++ b/src/main/java/com/tutti/server/core/config/FaqAsyncConfig.java
@@ -1,0 +1,13 @@
+package com.tutti.server.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * FAQ 서비스의 비동기 처리 활성화 설정 클래스
+ */
+@Configuration
+@EnableAsync
+public class FaqAsyncConfig {
+
+}

--- a/src/main/java/com/tutti/server/core/faq/api/FaqController.java
+++ b/src/main/java/com/tutti/server/core/faq/api/FaqController.java
@@ -1,19 +1,29 @@
 package com.tutti.server.core.faq.api;
 
 import com.tutti.server.core.faq.application.FaqService;
+import com.tutti.server.core.faq.payload.request.FaqDetailRequest;
 import com.tutti.server.core.faq.payload.request.FaqSearchRequest;
 import com.tutti.server.core.faq.payload.response.FaqListResponse;
 import com.tutti.server.core.faq.payload.response.FaqResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
+/**
+ * FAQ 관련 API 컨트롤러
+ */
 @Tag(name = "FAQ", description = "FAQ 관련 API")
 @RestController
 @RequestMapping("/api/faqs")
@@ -22,22 +32,54 @@ public class FaqController {
 
     private final FaqService faqService;
 
+    /**
+     * FAQ 카테고리 목록 조회
+     *
+     * @return 중복 제거된 FAQ 메인 카테고리 목록
+     */
     @Operation(summary = "FAQ 카테고리 목록 조회", description = "FAQ에서 사용되는 카테고리 목록을 반환합니다.")
     @GetMapping("/categories")
     public ResponseEntity<List<String>> getCategories() {
-        return ResponseEntity.ok(
-            faqService.getCategories());// faqService.getCategories() -> faqCategoryRepository.findDistinctMainCategories()
+        return ResponseEntity.ok(faqService.getCategories());
     }
 
+    /**
+     * 조회수가 높은 FAQ 목록 조회
+     *
+     * @return 조회수가 높은 상위 10개의 FAQ 목록
+     */
     @Operation(summary = "FAQ 인기 질문 목록 조회", description = "조회수가 가장 높은 상위 10개의 FAQ를 반환합니다.")
     @GetMapping("/top")
     public ResponseEntity<List<FaqResponse>> getTopFaqs() {
-        return ResponseEntity.ok(faqService.getTopFaqs(10)); // 상위 10개 FAQ 반환
+        return ResponseEntity.ok(faqService.getTopFaqs(10));
     }
 
+    /**
+     * FAQ 목록 조회 (검색어 및 카테고리 필터 적용 가능)
+     *
+     * @param request 검색 조건을 포함한 요청 객체
+     * @return 검색 조건에 맞는 FAQ 목록
+     */
     @Operation(summary = "FAQ 목록 조회", description = "카테고리 및 검색어를 기반으로 FAQ 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<FaqListResponse> getFaqs(FaqSearchRequest request) {
         return ResponseEntity.ok(faqService.getFaqs(request));
+    }
+
+    /**
+     * FAQ 단건 조회
+     *
+     * @param request 조회할 FAQ ID를 포함한 요청 객체
+     * @return 조회된 FAQ 정보
+     */
+    @Operation(summary = "FAQ 단건 조회", description = "FAQ ID를 기반으로 특정 FAQ 정보를 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "FAQ 조회 성공", content = @Content(schema = @Schema(implementation = FaqResponse.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (FAQ ID 없음)", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/detail")
+    public ResponseEntity<FaqResponse> getFaqById(@RequestBody FaqDetailRequest request) {
+        return ResponseEntity.ok(faqService.getFaqById(request.faqId()));
     }
 }

--- a/src/main/java/com/tutti/server/core/faq/application/FaqService.java
+++ b/src/main/java/com/tutti/server/core/faq/application/FaqService.java
@@ -6,11 +6,13 @@ import com.tutti.server.core.faq.infrastructure.FaqRepository;
 import com.tutti.server.core.faq.payload.request.FaqSearchRequest;
 import com.tutti.server.core.faq.payload.response.FaqListResponse;
 import com.tutti.server.core.faq.payload.response.FaqResponse;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,10 +34,10 @@ public class FaqService {
     }
 
     /**
-     * FAQ 목록 조회 (삭제되지 않고 isView가 true인 데이터만)
+     * FAQ 목록 조회 (삭제되지 않고, isView가 true인 데이터만)
      *
-     * @param request FAQ 검색 조건을 담은 요청 객체
-     * @return 검색 조건에 맞는 FAQ 목록 응답 객체
+     * @param request 검색 조건을 포함한 요청 객체
+     * @return 검색 조건에 맞는 FAQ 목록
      */
     @Transactional(readOnly = true)
     public FaqListResponse getFaqs(FaqSearchRequest request) {
@@ -51,45 +53,10 @@ public class FaqService {
     }
 
     /**
-     * FAQ 검색 조건을 기반으로 FAQ 데이터를 조회
-     *
-     * @param request     FAQ 검색 조건을 담은 요청 객체
-     * @param pageRequest 페이지네이션 정보
-     * @return FAQ 목록을 FaqResponse 형태로 변환한 Page 객체
-     */
-    private Page<FaqResponse> findFaqs(FaqSearchRequest request, PageRequest pageRequest) {
-        Page<Faq> faqs;
-
-        // 검색어(query)가 있는 경우 해당 키워드를 포함하는 FAQ 조회
-        if (request.query() != null && !request.query().isEmpty()) {
-            faqs = faqRepository.findByQuestionContainingIgnoreCaseAndDeleteStatusFalseAndIsViewTrue(
-                request.query(), pageRequest);
-
-            // 특정 카테고리 및 서브카테고리 기반 조회
-        } else if (request.category() != null && request.subcategory() != null) {
-            faqs = faqRepository.findByFaqCategory_MainCategoryAndFaqCategory_SubCategoryAndDeleteStatusFalseAndIsViewTrue(
-                request.category(), request.subcategory(), pageRequest);
-
-            // 기본적으로 삭제되지 않고 isView가 true인 모든 FAQ 조회
-        } else {
-            faqs = faqRepository.findByDeleteStatusFalseAndIsViewTrue(pageRequest);
-        }
-
-        // Page<Faq> → Page<FaqResponse> 변환
-        return faqs.map(faq -> new FaqResponse(
-            faq.getId(),
-            faq.getCategoryName(),
-            faq.getQuestion(),
-            faq.getAnswer(),
-            faq.getViewCnt()
-        ));
-    }
-
-    /**
-     * 조회수가 높은 FAQ 상위 N개 조회 (삭제되지 않고 isView가 true인 데이터만)
+     * 조회수가 높은 FAQ 상위 N개 조회
      *
      * @param limit 조회할 FAQ 개수
-     * @return 조회수가 높은 FAQ 목록을 FaqResponse 형태로 변환한 리스트
+     * @return 조회수가 높은 FAQ 목록
      */
     @Transactional(readOnly = true)
     public List<FaqResponse> getTopFaqs(int limit) {
@@ -97,6 +64,56 @@ public class FaqService {
         return faqRepository.findTopFaqs(pageable)
             .stream()
             .map(FaqResponse::fromEntity)
-            .toList(); // Java 16부터 사용 가능
+            .toList();
+    }
+
+    /**
+     * FAQ 단건 조회 (삭제되지 않고, isView가 true인 데이터만) 조회 시 조회수를 증가시킴 (비동기 처리)
+     *
+     * @param faqId 조회할 FAQ ID
+     * @return 조회된 FAQ 정보
+     */
+    @Transactional
+    public FaqResponse getFaqById(Long faqId) {
+        Faq faq = faqRepository.findByIdAndDeleteStatusFalseAndIsViewTrue(faqId)
+            .orElseThrow(() -> new EntityNotFoundException("FAQ를 찾을 수 없습니다. ID: " + faqId));
+
+        incrementViewCount(faqId); // 조회수 증가 (비동기 실행)
+
+        return FaqResponse.fromEntity(faq);
+    }
+
+    /**
+     * FAQ 조회수 증가 (비동기 실행) 새로운 트랜잭션에서 실행되며, 기존 요청 응답과 독립적으로 실행됨
+     *
+     * @param faqId 조회수가 증가할 FAQ ID
+     */
+    @Async
+    @Transactional
+    public void incrementViewCount(Long faqId) {
+        faqRepository.incrementViewCount(faqId);
+    }
+
+    /**
+     * 검색 조건을 기반으로 FAQ 데이터를 조회
+     *
+     * @param request     검색 조건이 포함된 요청 객체
+     * @param pageRequest 페이지네이션 정보
+     * @return 검색 조건에 맞는 FAQ 목록
+     */
+    private Page<FaqResponse> findFaqs(FaqSearchRequest request, PageRequest pageRequest) {
+        Page<Faq> faqs;
+
+        if (request.query() != null && !request.query().isEmpty()) {
+            faqs = faqRepository.findByQuestionContainingIgnoreCaseAndDeleteStatusFalseAndIsViewTrue(
+                request.query(), pageRequest);
+        } else if (request.category() != null && request.subcategory() != null) {
+            faqs = faqRepository.findByFaqCategory_MainCategoryAndFaqCategory_SubCategoryAndDeleteStatusFalseAndIsViewTrue(
+                request.category(), request.subcategory(), pageRequest);
+        } else {
+            faqs = faqRepository.findByDeleteStatusFalseAndIsViewTrue(pageRequest);
+        }
+
+        return faqs.map(FaqResponse::fromEntity);
     }
 }

--- a/src/main/java/com/tutti/server/core/faq/infrastructure/FaqRepository.java
+++ b/src/main/java/com/tutti/server/core/faq/infrastructure/FaqRepository.java
@@ -5,32 +5,48 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FaqRepository extends JpaRepository<Faq, Long> {
 
-    // 특정 카테고리의 FAQ 목록 조회 (삭제되지 않고, isView = true인 데이터만)
+    /**
+     * 특정 카테고리 및 서브카테고리의 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만)
+     */
     Page<Faq> findByFaqCategory_MainCategoryAndFaqCategory_SubCategoryAndDeleteStatusFalseAndIsViewTrue(
         String mainCategory, String subCategory, Pageable pageable);
 
-    // 특정 키워드를 포함하는 FAQ 목록 조회 (삭제되지 않고, isView = true인 데이터만)
+    /**
+     * 특정 키워드를 포함하는 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만)
+     */
     Page<Faq> findByQuestionContainingIgnoreCaseAndDeleteStatusFalseAndIsViewTrue(
         String query, Pageable pageable);
 
-    // 전체 FAQ 조회 (삭제되지 않고, isView = true인 데이터만)
+    /**
+     * 전체 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만)
+     */
     Page<Faq> findByDeleteStatusFalseAndIsViewTrue(Pageable pageable);
 
-    // 인기 FAQ 조회 (삭제되지 않고, isView = true인 데이터만, 조회수 기준 정렬)
-    @Query("SELECT f FROM Faq f WHERE f.deletedAt IS NULL AND f.isView = true ORDER BY f.viewCnt DESC")
-    @EntityGraph(attributePaths = {"faqCategory"})
+    /**
+     * 인기 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만, 조회수 기준 정렬)
+     */
+    @Query("SELECT f FROM Faq f WHERE f.deleteStatus = false AND f.isView = true ORDER BY f.viewCnt DESC")
     List<Faq> findTopFaqs(Pageable pageable);
 
-    // 특정 ID의 단일 FAQ 조회 (삭제되지 않고, isView = true인 데이터만)
+    /**
+     * 특정 ID의 FAQ 조회 (삭제되지 않고 isView = true인 데이터만)
+     */
     @Query("SELECT f FROM Faq f WHERE f.id = :faqId AND f.deleteStatus = false AND f.isView = true")
-    Optional<Faq> findByIdAndDeleteStatusFalseAndIsViewTrue(Long faqId);
+    Optional<Faq> findByIdAndDeleteStatusFalseAndIsViewTrue(@Param("faqId") Long faqId);
 
+    /**
+     * 조회수 증가 (UPDATE 쿼리 실행)
+     */
+    @Modifying
+    @Query("UPDATE Faq f SET f.viewCnt = f.viewCnt + 1 WHERE f.id = :faqId")
+    void incrementViewCount(@Param("faqId") Long faqId);
 }

--- a/src/main/java/com/tutti/server/core/faq/payload/request/FaqDetailRequest.java
+++ b/src/main/java/com/tutti/server/core/faq/payload/request/FaqDetailRequest.java
@@ -1,0 +1,10 @@
+package com.tutti.server.core.faq.payload.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record FaqDetailRequest(
+    @Schema(description = "조회할 FAQ ID", example = "1")
+    Long faqId
+) {
+
+}


### PR DESCRIPTION
1. Faq 조회수 비동기 처리 추가
2. FaqRequest 레코드 작성
3. 주석 정리

<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #116 

---

### 🚀 어떤 기능을 구현했나요 ?

1. **FAQ 조회수 비동기 처리**
   - `@Async`를 적용하여 `incrementViewCount()` 메서드를 비동기 실행하도록 변경
   - FAQ 조회 시 응답 속도 최적화

2. **FaqRequest 레코드 추가**
   - FAQ 관련 요청 데이터를 처리하는 `FaqRequest` 레코드 작성
   - DTO와 역할을 분리하여 코드의 가독성과 유지보수성을 향상

3. **주석 정리 및 코드 리팩토링**
   - 불필요한 주석 제거 및 가독성 향상
   - `@param`, `@return` 등의 문서를 보강하여 Swagger 문서화 개선

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

