### PR TITLE
[BE] 이메일 회원가입시 약관 동의 여부 추가

### DIFF
--- a/src/main/java/com/tutti/server/core/member/application/MemberService.java
+++ b/src/main/java/com/tutti/server/core/member/application/MemberService.java
@@ -1,10 +1,17 @@
 package com.tutti.server.core.member.application;
 
 import com.tutti.server.core.member.domain.Member;
+import com.tutti.server.core.member.domain.MemberAgreementMapping;
+import com.tutti.server.core.member.domain.TermsConditions;
+import com.tutti.server.core.member.infrastructure.MemberAgreementMappingRepository;
 import com.tutti.server.core.member.infrastructure.MemberRepository;
+import com.tutti.server.core.member.infrastructure.TermsConditionsRepository;
 import com.tutti.server.core.member.infrastructure.VerificationCodeRepository;
 import com.tutti.server.core.member.payload.SignupRequest;
-import com.tutti.server.core.member.utils.NicknameGenerator;
+import com.tutti.server.core.member.payload.TermsAgreementRequest;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,8 +23,29 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final VerificationCodeRepository verificationCodeRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TermsConditionsRepository termsConditionsRepository;
+    private final MemberAgreementMappingRepository memberAgreementMappingRepository;
 
     public void signup(SignupRequest request) {
+
+        // 1. 필수 약관 조회
+        List<TermsConditions> requiredTerms = termsConditionsRepository.findAll().stream()
+                .filter(TermsConditions::isRequired) // 필수 약관만 필터링
+                .toList();
+
+        // 2. 사용자가 제공한 약관 동의 데이터
+        Map<Long, Boolean> userAgreements = request.termsAgreement().stream()
+                .collect(Collectors.toMap(TermsAgreementRequest::termId,
+                        TermsAgreementRequest::agreed));
+
+        // 3. 필수 약관 동의 여부 검증
+        for (TermsConditions terms : requiredTerms) {
+            if (!userAgreements.getOrDefault(terms.getId(), false)) {
+                throw new IllegalArgumentException(
+                        "필수 약관(" + terms.getTermsType().getDescription() + ")에 동의해야 합니다.");
+            }
+        }
+        // 회원 정보 저장
         // 1. 필수 필드 검증
         if (request.email() == null || request.password() == null
                 || request.passwordConfirm() == null) {
@@ -41,14 +69,27 @@ public class MemberService {
         if (!verificationCode.isVerified()) {
             throw new IllegalArgumentException("이메일 인증을 완료해야 회원가입이 가능합니다.");
         }
-        // 5️. 닉네임 자동 생성
-        String nickname = NicknameGenerator.generateNickname(request.email());
 
-        // 6. 비밀번호 해싱 후 저장
+        // 5. 비밀번호 해싱 후 저장
         String encodedPassword = passwordEncoder.encode(request.password());
         Member member = Member.createEmailMember(request.email(), encodedPassword);
 
         member.verifyEmail();
         memberRepository.save(member);
+
+        // 약관 동의 정보 저장
+        for (TermsAgreementRequest termsAgreement : request.termsAgreement()) {
+            TermsConditions terms = termsConditionsRepository.findById(termsAgreement.termId())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "유효하지 않은 약관 ID: " + termsAgreement.termId()));
+
+            MemberAgreementMapping agreementMapping = MemberAgreementMapping.builder()
+                    .member(member)
+                    .termsConditions(terms)
+                    .isApproved(termsAgreement.agreed())
+                    .build();
+
+            memberAgreementMappingRepository.save(agreementMapping);
+        }
     }
 }

--- a/src/main/java/com/tutti/server/core/member/domain/Member.java
+++ b/src/main/java/com/tutti/server/core/member/domain/Member.java
@@ -1,5 +1,7 @@
 package com.tutti.server.core.member.domain;
 
+import static com.tutti.server.core.member.utils.NicknameGenerator.generateNickname;
+
 import com.tutti.server.core.support.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -77,13 +79,6 @@ public class Member extends BaseEntity {
         this.nickname = generateNickname(email); // 자동 생성
         this.memberStatus = MemberStatus.ACTIVE;
         this.isEmailVerified = false;
-    }
-
-    private String generateNickname(String email) {
-        if (email != null && email.contains("@")) {
-            return email.split("@")[0];
-        }
-        return "user" + System.currentTimeMillis(); // 예외 처리
     }
 
     public static Member createEmailMember(String email, String password) {

--- a/src/main/java/com/tutti/server/core/member/domain/TermsConditions.java
+++ b/src/main/java/com/tutti/server/core/member/domain/TermsConditions.java
@@ -1,8 +1,15 @@
 package com.tutti.server.core.member.domain;
 
 import com.tutti.server.core.support.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -11,15 +18,20 @@ import lombok.*;
 public class TermsConditions extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
-    @Column(name="terms_type",nullable = false, unique = true)
+    @Column(name = "terms_type", nullable = false, unique = true)
     private TermsType termsType;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content; // 약관 내용
 
+
     @Builder
     public TermsConditions(TermsType termsType, String content) {
         this.termsType = termsType;
         this.content = content;
+    }
+
+    public boolean isRequired() {
+        return this.termsType.isRequired();
     }
 }

--- a/src/main/java/com/tutti/server/core/member/domain/TermsType.java
+++ b/src/main/java/com/tutti/server/core/member/domain/TermsType.java
@@ -5,13 +5,15 @@ import lombok.Getter;
 @Getter
 public enum TermsType {
 
-    TERMS_OF_SERVICE("이용약관"),
-    PRIVACY_POLICY("개인정보처리방침"),
-    MARKETING_CONTENT("마케팅정보수신동의");
+    TERMS_OF_SERVICE("이용약관", true),
+    PRIVACY_POLICY("개인정보처리방침", true),
+    MARKETING_CONTENT("마케팅정보수신동의", false);
 
     private final String description;
+    private final boolean required;
 
-    TermsType(String description) {
+    TermsType(String description, boolean required) {
         this.description = description;
+        this.required = required;
     }
 }

--- a/src/main/java/com/tutti/server/core/member/infrastructure/MemberAgreementMappingRepository.java
+++ b/src/main/java/com/tutti/server/core/member/infrastructure/MemberAgreementMappingRepository.java
@@ -1,0 +1,9 @@
+package com.tutti.server.core.member.infrastructure;
+
+import com.tutti.server.core.member.domain.MemberAgreementMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberAgreementMappingRepository extends
+        JpaRepository<MemberAgreementMapping, Long> {
+
+}

--- a/src/main/java/com/tutti/server/core/member/infrastructure/TermsConditionsRepository.java
+++ b/src/main/java/com/tutti/server/core/member/infrastructure/TermsConditionsRepository.java
@@ -1,0 +1,8 @@
+package com.tutti.server.core.member.infrastructure;
+
+import com.tutti.server.core.member.domain.TermsConditions;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermsConditionsRepository extends JpaRepository<TermsConditions, Long> {
+
+}

--- a/src/main/java/com/tutti/server/core/member/payload/SignupRequest.java
+++ b/src/main/java/com/tutti/server/core/member/payload/SignupRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.List;
 
 public record SignupRequest(
 
@@ -22,7 +23,9 @@ public record SignupRequest(
         String password,
 
         @NotBlank(message = "비밀번호 확인은 필수 입력 항목입니다.")
-        String passwordConfirm
+        String passwordConfirm,
+
+        List<TermsAgreementRequest> termsAgreement
 ) {
 
 }

--- a/src/main/java/com/tutti/server/core/member/payload/TermsAgreementRequest.java
+++ b/src/main/java/com/tutti/server/core/member/payload/TermsAgreementRequest.java
@@ -1,0 +1,13 @@
+package com.tutti.server.core.member.payload;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TermsAgreementRequest(
+        @NotNull(message = "약관 ID는 필수 입력 항목입니다.")
+        Long termId,
+
+        @NotNull(message = "약관 동의 여부는 필수 입력 항목입니다.")
+        Boolean agreed
+) {
+
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #169
---

### 🚀 어떤 기능을 구현했나요 ?

- 회원가입시 동의 받고 필수 항목 미동의 시 넘어가지 않도록 함
- 닉네임 함수 중복 제거

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

