### PR TITLE
Repository > findById 메서드 일괄 변경

### DIFF
--- a/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
+++ b/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
@@ -1,14 +1,21 @@
 package com.tutti.server.core.cart.infrastructure;
 
 import com.tutti.server.core.cart.domain.CartItem;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
+    default CartItem findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.CART_ITEM_NOT_FOUND));
+    }
+
     Optional<CartItem> findByIdAndMemberIdAndDeleteStatusFalse(Long cartItemId, Long memberId);
-    
+
     Optional<CartItem> findByMemberIdAndProductItemIdAndDeleteStatusFalse(Long memberId,
             Long productItemId);
 

--- a/src/main/java/com/tutti/server/core/faq/infrastructure/FaqCategoryRepository.java
+++ b/src/main/java/com/tutti/server/core/faq/infrastructure/FaqCategoryRepository.java
@@ -2,6 +2,8 @@ package com.tutti.server.core.faq.infrastructure;
 
 import com.tutti.server.core.faq.domain.FaqCategory;
 import com.tutti.server.core.faq.payload.response.FaqCategoryResponse;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +11,11 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> {
+
+    default FaqCategory findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.FAQ_CATEGORY_NOT_FOUND));
+    }
 
     // 메인 카테고리 목록만 조회 (중복 제거)
     @Query("SELECT DISTINCT f.mainCategory FROM FaqCategory f")

--- a/src/main/java/com/tutti/server/core/faq/infrastructure/FaqRepository.java
+++ b/src/main/java/com/tutti/server/core/faq/infrastructure/FaqRepository.java
@@ -1,6 +1,8 @@
 package com.tutti.server.core.faq.infrastructure;
 
 import com.tutti.server.core.faq.domain.Faq;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -14,17 +16,22 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FaqRepository extends JpaRepository<Faq, Long> {
 
+    default Faq findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.FAQ_NOT_FOUND));
+    }
+
     /**
      * 특정 카테고리 및 서브카테고리의 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만)
      */
     Page<Faq> findByFaqCategory_MainCategoryAndFaqCategory_SubCategoryAndDeleteStatusFalseAndIsViewTrue(
-        String mainCategory, String subCategory, Pageable pageable);
+            String mainCategory, String subCategory, Pageable pageable);
 
     /**
      * 특정 키워드를 포함하는 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만)
      */
     Page<Faq> findByQuestionContainingIgnoreCaseAndDeleteStatusFalseAndIsViewTrue(
-        String query, Pageable pageable);
+            String query, Pageable pageable);
 
     /**
      * 전체 FAQ 목록 조회 (삭제되지 않고 isView = true인 데이터만)

--- a/src/main/java/com/tutti/server/core/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/tutti/server/core/member/infrastructure/MemberRepository.java
@@ -1,10 +1,17 @@
 package com.tutti.server.core.member.infrastructure;
 
 import com.tutti.server.core.member.domain.Member;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.MEMBER_NOT_FOUND));
+    }
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/tutti/server/core/member/infrastructure/VerificationCodeRepository.java
+++ b/src/main/java/com/tutti/server/core/member/infrastructure/VerificationCodeRepository.java
@@ -1,10 +1,17 @@
 package com.tutti.server.core.member.infrastructure;
 
 import com.tutti.server.core.member.domain.VerificationCode;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
+
+    default VerificationCode findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.INVALID_VERIFICATION_CODE));
+    }
 
     Optional<VerificationCode> findByEmail(String email);
 

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
@@ -1,8 +1,14 @@
 package com.tutti.server.core.order.infrastructure;
 
 import com.tutti.server.core.order.domain.Order;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
+    default Order findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.ORDER_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/tutti/server/core/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/payment/application/PaymentServiceImpl.java
@@ -34,8 +34,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     // 주문 정보 검증 메서드
     private Order validateOrder(Long orderId) {
-        return orderRepository.findById(orderId)
-                .orElseThrow(() -> new DomainException(ExceptionType.ORDER_NOT_FOUND));
+        return orderRepository.findOne(orderId);
     }
 
     // 기존 결제 여부 검증 메서드

--- a/src/main/java/com/tutti/server/core/payment/infrastructure/PaymentRepository.java
+++ b/src/main/java/com/tutti/server/core/payment/infrastructure/PaymentRepository.java
@@ -1,10 +1,17 @@
 package com.tutti.server.core.payment.infrastructure;
 
 import com.tutti.server.core.payment.domain.Payment;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    default Payment findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.PAYMENT_NOT_FOUND));
+    }
 
     Optional<Payment> findByOrderId(Long orderId);
 

--- a/src/main/java/com/tutti/server/core/product/infrastructure/ProductItemRepository.java
+++ b/src/main/java/com/tutti/server/core/product/infrastructure/ProductItemRepository.java
@@ -1,8 +1,15 @@
 package com.tutti.server.core.product.infrastructure;
 
 import com.tutti.server.core.product.domain.ProductItem;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductItemRepository extends JpaRepository<ProductItem, Long> {
+
+    default ProductItem findOne(Long id) {
+        return findById(id)
+                .orElseThrow(() -> new DomainException(ExceptionType.PRODUCT_NOT_FOUND));
+    }
 
 }

--- a/src/main/java/com/tutti/server/core/support/exception/ExceptionCode.java
+++ b/src/main/java/com/tutti/server/core/support/exception/ExceptionCode.java
@@ -3,5 +3,10 @@ package com.tutti.server.core.support.exception;
 public enum ExceptionCode {
 
     E401, E500,
-    P01, P02, P03, P04;
+    A01, A02, A03, A04, A05, A06, A07, A08,
+    B01, B02, B03, B04,
+    C01,
+    D01,
+    P01, P02, P03, P04,
+    F01, F02;
 }

--- a/src/main/java/com/tutti/server/core/support/exception/ExceptionType.java
+++ b/src/main/java/com/tutti/server/core/support/exception/ExceptionType.java
@@ -2,6 +2,7 @@ package com.tutti.server.core.support.exception;
 
 import static com.tutti.server.core.support.exception.ExceptionCode.E500;
 import static org.springframework.boot.logging.LogLevel.ERROR;
+import static org.springframework.boot.logging.LogLevel.INFO;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import lombok.Getter;
@@ -12,11 +13,41 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionType {
 
     DEFAULT_ERROR(INTERNAL_SERVER_ERROR, E500, "알 수 없는 이유로 서버에서 요청을 처리할 수 없습니다.", ERROR),
+    UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, ExceptionCode.E401, "권한이 없습니다", INFO),
 
-    ORDER_NOT_FOUND(ExceptionCode.P01, "해당 주문을 찾을 수 없습니다."),
+    // - 회원 -
+    DUPLICATE_NICKNAME(ExceptionCode.A01, "중복된 닉네임으로 회원가입했습니다."),
+    MEMBER_NOT_FOUND(ExceptionCode.A02, "회원이 존재하지 않습니다."),
+    DUPLICATE_EMAIL(ExceptionCode.A03, "중복된 이메일로 회원가입했습니다."),
+    LOGIN_FAIL(ExceptionCode.A04, "존재하지 않는 아이디 혹은 이메일입니다."),
+
+    ACCOUNT_LOCKED(ExceptionCode.A05, "현재 계정이 잠금 상태입니다"),
+    REQUIRE_EMAIL_AUTHENTICATION(ExceptionCode.A06, "이메일 인증 전입니다. 이메일 인증을 해주세요"),
+    REQUIRE_UNLOCK_DORMANT(ExceptionCode.A07, "현재 계정이 휴면상태입니다."),
+
+    INVALID_VERIFICATION_CODE(ExceptionCode.A08, "유효하지 않은 인증 코드입니다."),
+
+    // - 상품 -
+    PRODUCT_NOT_FOUND(ExceptionCode.B01, "존재하지 않는 상품입니다."),
+    PRODUCT_QNA_NOT_FOUND(ExceptionCode.B02, "존재하지 않는 QnA 입니다."),
+    PRODUCT_REVIEW_NOT_FOUND(ExceptionCode.B03, "존재하지 않는 리뷰 입니다."),
+    CATEGORY_NOT_FOUND(ExceptionCode.B04, "존재하지 않는 카테고리입니다."),
+
+    // - 장바구니 -
+    CART_ITEM_NOT_FOUND(ExceptionCode.C01, "존재하지 않는 상품입니다."),
+
+    // - 주문 -
+    ORDER_NOT_FOUND(ExceptionCode.D01, "해당 주문을 찾을 수 없습니다."),
+
+    // - 결제 -
+    PAYMENT_NOT_FOUND(ExceptionCode.P01, "해당 결제 내역을 찾을 수 없습니다."),
     PAYMENT_AMOUNT_MISMATCH(ExceptionCode.P02, "결제 금액과 주문 금액이 일치하지 않습니다."),
     PAYMENT_ALREADY_COMPLETED(ExceptionCode.P03, "이미 결제가 완료된 주문입니다."),
-    PAYMENT_ALREADY_PROCESSING(ExceptionCode.P04, "이미 결제가 진행 중인 주문입니다.");
+    PAYMENT_ALREADY_PROCESSING(ExceptionCode.P04, "이미 결제가 진행 중인 주문입니다."),
+
+    // - FAQ -
+    FAQ_NOT_FOUND(ExceptionCode.F01, "존재하지 않는 FAQ 입니다."),
+    FAQ_CATEGORY_NOT_FOUND(ExceptionCode.F02, "존재하지 않는 카테고리입니다.");
 
     private final HttpStatus status;
 


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #172 

---

### 🚀 어떤 기능을 구현했나요 ?
1. Repository 파일 내 findById -> findOne 메서드 일괄 변경
2. 사유: 자주 사용하는 메서드를 더욱 간편하고 깔끔하게 사용하기 위해서
3. 효과: 사용도 🆙 가독성 🆙
4. 용법: 기존에 사용하던 findById()를 -> findOne으로 바꿔쓰면 댑니다!
5. 예외처리(ElseThrow(() -> Exception) 없이! 오히려 좋아~~

### 🔥 어떻게 해결했나요 ?
- 수정완료
- ProductItemRepository.java
- PaymentRepository.java
- OrderRepository.java
- VerificationCodeRepository.java
- MemberRepository.java
- FaqCategoryRepository.java
- CartItemRepository.java
- FaqRepository.java

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
오히려 좋아~~~~
