### PR TITLE
Feat: 관리자 기능 추가(FAQ등록)

### DIFF
--- a/src/main/java/com/tutti/server/core/faq/api/FaqAdminApiSpec.java
+++ b/src/main/java/com/tutti/server/core/faq/api/FaqAdminApiSpec.java
@@ -1,0 +1,15 @@
+package com.tutti.server.core.faq.api;
+
+import com.tutti.server.core.faq.payload.request.FaqCreateRequest;
+import com.tutti.server.core.faq.payload.response.FaqCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "FAQ 관리자 API")
+public interface FaqAdminApiSpec {
+
+    @Operation(summary = "FAQ 등록", description = "관리자가 FAQ를 등록한다.")
+    ResponseEntity<FaqCreateResponse> createFaq(@RequestBody FaqCreateRequest faqCreateRequest);
+}

--- a/src/main/java/com/tutti/server/core/faq/api/FaqAdminApiSpecImpl.java
+++ b/src/main/java/com/tutti/server/core/faq/api/FaqAdminApiSpecImpl.java
@@ -1,0 +1,35 @@
+package com.tutti.server.core.faq.api;
+
+import com.tutti.server.core.faq.application.admin.FaqAdminServiceImpl;
+import com.tutti.server.core.faq.payload.request.FaqCreateRequest;
+import com.tutti.server.core.faq.payload.response.FaqCreateResponse;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("faqs")
+@RequiredArgsConstructor
+public class FaqAdminApiSpecImpl implements FaqAdminApiSpec {
+
+    private final FaqAdminServiceImpl faqAdminServiceImpl;
+
+    @Override
+    @PostMapping
+    public ResponseEntity<FaqCreateResponse> createFaq(
+        @RequestBody FaqCreateRequest faqCreateRequest) {
+        try {
+            FaqCreateResponse response = faqAdminServiceImpl.createFaq(faqCreateRequest);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            throw new DomainException(ExceptionType.MISSING_REQUIRED_FIELD);
+        } catch (Exception e) {
+            throw new DomainException(ExceptionType.FAQ_FEEDBACK_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminCreateService.java
+++ b/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminCreateService.java
@@ -1,0 +1,9 @@
+package com.tutti.server.core.faq.application.admin;
+
+import com.tutti.server.core.faq.payload.request.FaqCreateRequest;
+import com.tutti.server.core.faq.payload.response.FaqCreateResponse;
+
+public interface FaqAdminCreateService {
+
+    FaqCreateResponse createFaq(FaqCreateRequest faqCreateRequest);
+}

--- a/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminCreateServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminCreateServiceImpl.java
@@ -1,0 +1,43 @@
+package com.tutti.server.core.faq.application.admin;
+
+import com.tutti.server.core.faq.domain.Faq;
+import com.tutti.server.core.faq.domain.FaqCategory;
+import com.tutti.server.core.faq.infrastructure.FaqCategoryRepository;
+import com.tutti.server.core.faq.infrastructure.FaqRepository;
+import com.tutti.server.core.faq.payload.request.FaqCreateRequest;
+import com.tutti.server.core.faq.payload.response.FaqCreateResponse;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FaqAdminCreateServiceImpl implements FaqAdminCreateService {
+
+    private final FaqRepository faqRepository;
+    private final FaqCategoryRepository faqCategoryRepository;
+
+    @Override
+    public FaqCreateResponse createFaq(FaqCreateRequest faqCreateRequest) {
+
+        FaqCategory faqCategory = faqCategoryRepository.findOne(faqCreateRequest.categoryId());
+        if (faqCategory == null) {
+            throw new DomainException(ExceptionType.FAQ_CATEGORY_NOT_FOUND, "지정된 카테고리가 존재하지 않습니다.");
+        }
+
+        Faq faq = Faq.builder()
+            .faqCategory(faqCategory)
+            .question(faqCreateRequest.question())
+            .answer(faqCreateRequest.answer())
+            .isView(faqCreateRequest.isView())
+            .build();
+
+        try {
+            faqRepository.save(faq);
+        } catch (Exception e) {
+            throw new DomainException(ExceptionType.FAQ_FEEDBACK_FAILED, "FAQ 저장에 실패했습니다.");
+        }
+        return new FaqCreateResponse(faq);
+    }
+}

--- a/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminService.java
+++ b/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminService.java
@@ -1,0 +1,11 @@
+package com.tutti.server.core.faq.application.admin;
+
+import com.tutti.server.core.faq.payload.request.FaqCreateRequest;
+import com.tutti.server.core.faq.payload.response.FaqCreateResponse;
+
+public interface FaqAdminService {
+
+    FaqCreateResponse createFaq(FaqCreateRequest faqCreateRequest);
+
+
+}

--- a/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/faq/application/admin/FaqAdminServiceImpl.java
@@ -1,0 +1,27 @@
+package com.tutti.server.core.faq.application.admin;
+
+import com.tutti.server.core.faq.payload.request.FaqCreateRequest;
+import com.tutti.server.core.faq.payload.response.FaqCreateResponse;
+import com.tutti.server.core.support.exception.DomainException;
+import com.tutti.server.core.support.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FaqAdminServiceImpl implements FaqAdminService {
+
+    private final FaqAdminCreateServiceImpl faqAdminCreateServiceImpl;
+
+    @Override
+    public FaqCreateResponse createFaq(FaqCreateRequest faqCreateRequest) {
+        try {
+            return faqAdminCreateServiceImpl.createFaq(faqCreateRequest);
+        } catch (DomainException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DomainException(ExceptionType.FAQ_FEEDBACK_FAILED,
+                "FAQ 생성 중 알 수 없는 오류가 발생했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/tutti/server/core/faq/payload/request/FaqCreateRequest.java
+++ b/src/main/java/com/tutti/server/core/faq/payload/request/FaqCreateRequest.java
@@ -16,15 +16,10 @@ public record FaqCreateRequest(
     @NotNull(message = "답변은 필수입니다.")
     @Schema(description = "FAQ 답변", example = "상품은 3일 이내에 배송됩니다.")
     String answer,
-    
+
     @NotNull(message = "보기 여부는 필수입니다.")
     @Schema(description = "FAQ 보이기 여부", example = "true")
     boolean isView
 ) {
 
-    public FaqCreateRequest {
-        if (categoryId == null || question == null || answer == null) {
-            throw new IllegalArgumentException("필수 값이 누락되었습니다.");
-        }
-    }
 }

--- a/src/main/java/com/tutti/server/core/faq/payload/response/FaqCreateResponse.java
+++ b/src/main/java/com/tutti/server/core/faq/payload/response/FaqCreateResponse.java
@@ -39,3 +39,5 @@ public record FaqCreateResponse(
         );
     }
 }
+
+


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #120 

---

### 🚀 어떤 기능을 구현했나요 ?

- 관리자 FAQ 등록

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
FAQ관리자 영역은 고도화 영역으로 넘긴 부분이고 프론트에서는 현재 구현 계획이 없다고 했습니다.
그러나 만약을 위해 미리 만들어 두려고 합니다.
로컬 서버에서 테스트해본 결과 문제없이 잘 동작합니다.
현재로서는 핵심 기능이 아니기 때문에 큰 오류가 없다면 머지 부탁드립니다.
앞으로 FAQ는 관리자의 CRUD 기능을 조금씩 추가하면서 마무리하겠습니다.
FAQ 관리자 등록, 수정, 삭제 관련 이슈가 생성되어 있으며, 이 이슈에 맞춰 2개의 PR을 추가로 진행할 예정입니다.
프로젝트 종료 시까지 코드 리팩토링 계획은 없으나, 필요 시 별도 이슈를 생성하여 대응하도록 하겠습니다.
미리 감사드립니다.