### PR TITLE
[BE] 페이지네이션 무한스크롤 추가

### DIFF
--- a/src/main/java/com/tutti/server/core/review/application/ReviewListServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/review/application/ReviewListServiceImpl.java
@@ -6,9 +6,9 @@ import com.tutti.server.core.review.payload.request.ReviewListRequest;
 import com.tutti.server.core.review.payload.response.ReviewListResponse;
 import com.tutti.server.core.review.payload.response.ReviewResponse;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -23,52 +23,42 @@ public class ReviewListServiceImpl implements ReviewListService {
     @Override
     public ReviewListResponse getReviews(ReviewListRequest request) {
         return getReviewsWithPagination(
-            request.productId(), 20, request.sort(), request.nextCursor());
+            request.productId(),
+            Optional.ofNullable(request.size()).orElse(20),
+            request.sort(),
+            request.nextCursor()
+        );
     }
-
 
     @Override
     public ReviewListResponse getReviewsWithPagination(Long productId, Integer size, String sort,
         String nextCursor) {
-        long cursorId = (nextCursor != null) ? Long.parseLong(nextCursor) : 0L;
-        Pageable pageable = PageRequest.of(0, size, getSort(sort));
+        Long cursorId = (nextCursor != null && !nextCursor.isEmpty()) ? Long.parseLong(nextCursor)
+            : Long.MAX_VALUE;
 
-        Page<Review> reviewsPage = reviewRepository.findByProductIdAndIdGreaterThan(
-            productId, cursorId, pageable);
+        Pageable pageable = PageRequest.of(0, size + 1, getSort(sort)); // size + 1 개 조회
 
-        List<ReviewResponse> reviewResponses = convertToReviewResponseList(reviewsPage);
+        List<Review> reviews = reviewRepository.findReviewsByProductIdAndCursor(productId, cursorId,
+            pageable);
 
-        String nextCursorValue = null;
-        if (reviewsPage.hasNext()) {
-            nextCursorValue = reviewsPage.getContent().get(reviewsPage.getContent().size() - 1)
-                .getId().toString();
-        }
+        // nextCursor 설정: 마지막으로 가져온 리뷰의 ID 사용
+        String nextCursorValue =
+            (reviews.size() > size) ? String.valueOf(reviews.get(size).getId()) : null;
+
+        // 응답 리스트: size만큼 잘라서 반환
+        List<ReviewResponse> reviewResponses = reviews.stream()
+            .limit(size)
+            .map(ReviewResponse::from)
+            .collect(Collectors.toList());
 
         return new ReviewListResponse(reviewResponses, nextCursorValue);
     }
 
     private Sort getSort(String sort) {
         return switch (sort.toLowerCase()) {
-            case "latest" -> Sort.by(Sort.Order.desc("latest"));
-            case "rating" -> Sort.by(Sort.Order.desc("rating"));
-            default -> Sort.by(Sort.Order.desc("createdAt"));
+            case "rating_desc" -> Sort.by(Sort.Order.desc("rating"));
+            case "like_desc" -> Sort.by(Sort.Order.desc("likeCount"));
+            default -> Sort.by(Sort.Order.desc("createdAt")); // 기본값: 최신순
         };
-    }
-
-    private ReviewResponse convertToReviewResponse(Review review) {
-        return new ReviewResponse(
-            review.getId(),
-            review.getProductId(),
-            review.getNickname(),
-            review.getContent(),
-            review.getRating(),
-            review.getCreatedAt()
-        );
-    }
-
-    private List<ReviewResponse> convertToReviewResponseList(Page<Review> reviewsPage) {
-        return reviewsPage.stream()
-            .map(this::convertToReviewResponse)
-            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/tutti/server/core/review/domain/Review.java
+++ b/src/main/java/com/tutti/server/core/review/domain/Review.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "reviews")
@@ -30,11 +31,23 @@ public class Review extends BaseEntity {
     @Column(nullable = false, length = 500)
     private String content;
 
-    // 리뷰 이미지 URL을 저장할 필드 (하드코딩된 이미지를 배열로 저장)
     @Column(name = "review_image_urls", length = 1000)
     private String reviewImageUrls;
 
-    @Column
+    @CreationTimestamp
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = false)
+    private int likeCount = 0;
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
 }

--- a/src/main/java/com/tutti/server/core/review/domain/ReviewLike.java
+++ b/src/main/java/com/tutti/server/core/review/domain/ReviewLike.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PreRemove;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -25,22 +26,17 @@ public class ReviewLike extends BaseEntity {
     @Column(name = "member_id", nullable = false, updatable = false)
     private Long memberId;
 
-    @Column(name = "is_liked", nullable = false)
-    private boolean isLiked;
-
     @CreationTimestamp
     private LocalDateTime createdAt;
 
     public ReviewLike(Review review, Long memberId) {
         this.review = review;
         this.memberId = memberId;
-        this.isLiked = true;
+        review.increaseLikeCount(); // 좋아요 추가 시 증가
     }
 
-    public void toggleLike(Long memberIdFromToken) {
-        if (!this.memberId.equals(memberIdFromToken)) {
-            throw new IllegalArgumentException("잘못된 사용자 요청입니다.");
-        }
-        this.isLiked = !this.isLiked;
+    @PreRemove
+    public void preRemove() {
+        review.decreaseLikeCount(); // 삭제 시 감소
     }
 }

--- a/src/main/java/com/tutti/server/core/review/infrastructure/ReviewRepository.java
+++ b/src/main/java/com/tutti/server/core/review/infrastructure/ReviewRepository.java
@@ -3,9 +3,11 @@ package com.tutti.server.core.review.infrastructure;
 import com.tutti.server.core.review.domain.Review;
 import com.tutti.server.core.support.exception.DomainException;
 import com.tutti.server.core.support.exception.ExceptionType;
-import org.springframework.data.domain.Page;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -16,8 +18,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             .orElseThrow(() -> new DomainException(ExceptionType.FAQ_NOT_FOUND));
     }
 
-    Page<Review> findByProductId(Long productId, Pageable pageable);
+    List<Review> findByProductId(Long productId, Pageable pageable);
 
-    // 수정된 부분: Page<Review>로 반환 타입 변경
-    Page<Review> findByProductIdAndIdGreaterThan(Long productId, Long id, Pageable pageable);
+    @Query("SELECT r FROM Review r WHERE r.productId = :productId AND r.id < :cursor ORDER BY r.createdAt DESC")
+    List<Review> findReviewsByProductIdAndCursor(@Param("productId") Long productId,
+        @Param("cursor") Long cursor, Pageable pageable);
+
 }

--- a/src/main/java/com/tutti/server/core/review/payload/request/ReviewListRequest.java
+++ b/src/main/java/com/tutti/server/core/review/payload/request/ReviewListRequest.java
@@ -13,12 +13,10 @@ public record ReviewListRequest(
     @Schema(description = "다음 페이지 조회를 위한 커서 값", example = "0") String nextCursor
 ) {
 
-    public ReviewListRequest {
-        if (size == null) {
-            size = 20;
-        }
-        if (sort == null) {
-            sort = "created_at_desc";
-        }
+    public ReviewListRequest(Long productId, Integer size, String sort, String nextCursor) {
+        this.productId = productId;
+        this.size = (size == null) ? 20 : size;
+        this.sort = (sort == null) ? "created_at_desc" : sort;
+        this.nextCursor = nextCursor;
     }
 }

--- a/src/main/java/com/tutti/server/core/review/payload/response/ReviewResponse.java
+++ b/src/main/java/com/tutti/server/core/review/payload/response/ReviewResponse.java
@@ -1,20 +1,33 @@
 package com.tutti.server.core.review.payload.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tutti.server.core.review.domain.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
 
-@Schema(description = "리뷰 응답")
+@Schema(description = "리뷰 응답 객체")
 public record ReviewResponse(
-    @Schema(description = "리뷰 ID", example = "1") Long id,
-    @Schema(description = "상품 ID", example = "1") Long productId,
-    @Schema(description = "리뷰 작성자 닉네임", example = "tutti") String nickname,
-    @Schema(description = "리뷰 내용", example = "상품이 좋아요!") String content,
+    @Schema(description = "리뷰 ID", example = "1") Long reviewId,
+    @Schema(description = "작성자 닉네임", example = "JohnDoe") String nickname,
     @Schema(description = "평점", example = "5") Integer rating,
-    @Schema(description = "리뷰 작성일", example = "2022-01-01 T10:00")
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    LocalDateTime createdAt
-
+    @Schema(description = "리뷰 내용", example = "이 제품 정말 좋아요!") String content,
+    @Schema(description = "리뷰 이미지 URL 목록") List<String> reviewImageUrls,
+    @Schema(description = "좋아요 개수", example = "15") int likeCount,
+    @Schema(description = "작성일", example = "2024-03-16T12:00:00") LocalDateTime createdAt
 ) {
 
+    public static ReviewResponse from(Review review) {
+        List<String> imageUrls = review.getReviewImageUrls() == null ?
+            List.of() : Arrays.asList(review.getReviewImageUrls().split(","));
+        return new ReviewResponse(
+            review.getId(),
+            review.getNickname(),
+            review.getRating(),
+            review.getContent(),
+            imageUrls,
+            review.getLikeCount(),
+            review.getCreatedAt()
+        );
+    }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #194 

---

### 🚀 어떤 기능을 구현했나요 ?

-  특정 상품의 리뷰 목록 조회 시 무한 스크롤 기반의 페이지네이션 기능 추가

### 🔥 어떻게 해결했나요 ?
-  nextCursor 기반 커서 페이지네이션 적용
- size + 1개의 데이터를 조회하여 다음 페이지 여부 판단
- 마지막 reviewId를 nextCursor로 설정하여 다음 요청 시 사용
- 정렬 기능 추가 (created_at_desc, rating_desc, like_desc )

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
로컬 서버 동작 확인 완료 (스웨거 UI 테스트)
- nextCursor가 올바르게 설정되어 무한 스크롤이 정상 동작하는지 확인
- 정렬 기준 적용(created_at_desc, rating_desc, like_desc)이 잘 반영되었는지 점검
- size + 1 조회 방식이 올바르게 작동하는지 테스트 필요

### 📚 참고 자료, 할 말
무한 스크롤 로직 정상 작동 확인
