### PR TITLE
[BE] 주문 내역 전체 조회

### DIFF
--- a/docs/Order.md
+++ b/docs/Order.md
@@ -3,28 +3,29 @@
 1. (CREATE) 유저는 상품을 주문할 수 있다.
     -[ ] 유저가 장바구니/상품 페이지에서 주문하기를 클릭하면 주문서 페이지로 넘어간다.
     -[ ] 주문서 페이지에서 결제하기 api를 요청하면 주문 상품 -> 주문 -> 결제 -> 주문이력 엔티티를 생성한다.(결제 대기 -> ...)
-    -[X] Order request: member의 인증 정보(회원일 경우), 결제수단, 주문 상품
+    -[X] Order request: member.email(member의 인증 정보), 결제수단, 주문 상품
         - 나머지는 직접 생성: ~~주문 상태, 주문 번호, 주문 상품 수, 주문 금액,~~ 주문 완료 일시
-        - 배송비는 우선 아예 안 받는 것으로 한다. deliveryFee default 0;(무료배송)
-    -[X] OrderItem request: member의 인증 정보(회원일 경우), product_item_id(상품명, 상품사진, 옵션, 가격), 수량
+        - ~~배송비는 우선 아예 안 받는 것으로 한다. deliveryFee default 0;(무료배송)~~
+    -[X] OrderItem request: member.email(member의 인증 정보), product_item_id(상품명, 상품사진, 옵션, 가격), 수량
     -[ ] Order response: orderId (결제 또는 배송한테 던져줄 용...?)
     -[X] 주문 엔티티 생성과 함께 주문 이력 엔티티도 생성된다.
     -[ ] 추후, 재고 DB와 연동하여 주문 행위에 따라 재고 관리가 되도록 한다.
 2. (READ) 유저는 주문한 상품의 내역을 확인할 수 있다.
     -[ ] 유저가 주문 내역 api를 요청하면 delete_status=false 인 내역만 반환한다.
-    -[ ] request: member의 인증 정보(회원일 경우)
+    -[X] request: member.email(member의 인증 정보)
     -[ ] response: order List
-        - 주문번호/주문한 날짜/총 결제 금액
-        - 상품 이미지/주문한 상품명/옵션/수량/가격
+        - ~~주문번호/주문한 날짜/총 결제 금액~~
+        - ~~주문 상태~~
+        - ~~상품 이미지/주문한 상품명/옵션/수량/가격~~
         - 예상 도착일(배송 도착 전 상품들만)
-        - 주문 상태
     -[ ] 유저는 주문 내역을 기간별로 필터링할 수 있다.
 3. (READ) 유저는 주문한 상품의 상세 내역을 확인할 수 있다.
     -[ ] 유저가 주문 상세 내역 api를 요청하면 상세 내역을 반환한다.
-    -[ ] request: member의 인증 정보(회원일 경우), orderId
+    -[ ] request: member.email(member의 인증 정보), orderId
     -[ ] response: order, orderItem List
         - 결제 금액 (합계, ~~할인 금액~~, 배송비, 총 결제 금액)
         - 결제 수단
+        - 상품 이미지/주문한 상품명/옵션/수량/가격
         - 주문 번호(orderNumber)
         - 주문 상태 및 배송 상태 (발송 준비 중(배송 전), 배송 중, 주문 완료)
         - 날짜 (주문일, 결제 완료일, 발송 완료일, 주문 완료일)
@@ -36,11 +37,11 @@
 4. (UPDATE) 유저는 결제 후 일정 기간 내 주문을 취소할 수 있다.
     -[ ] 주문이 출고되지 않은 경우 즉시 결제 취소가 가능하며, 출고된 경우 취소가 불가능하고 반품 절차로 전환된다.
     -[ ] 결제 취소가 완료되면 주문 상태를 ‘취소 완료’로 업데이트한다.
-    -[ ] request: member의 인증 정보(-> 목록 조회 때문에), orderId
+    -[ ] request: member.email(member의 인증 정보), orderId
     -[ ] 주문 상태를 결제 취소로 업데이트한다.
     -[ ] response: 없다.
 5. (DELETE) 유저는 주문 내역을 제거할 수 있다.
     -[ ] 유저가 주문 내역 삭제(버튼) api를 요청하면, delete_status=true 로 업데이트한다.
     -[ ] response: 없다.
-    -[ ] request: member의 인증 정보(-> 목록 조회 때문에), orderId
+    -[ ] request: member.email(member의 인증 정보), orderId
     -[ ] 해당 상품의 delete_status=true로 update 한다.

--- a/src/main/java/com/tutti/server/core/order/api/OrderApi.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApi.java
@@ -6,8 +6,6 @@ import com.tutti.server.core.order.payload.response.OrderResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,7 +28,7 @@ public class OrderApi implements OrderApiSpec {
     // 주문 전체 조회
     @Override
     @GetMapping
-    public List<OrderResponse> getOrders(@AuthenticationPrincipal UserDetails user) {
-        return orderService.getOrders(user.getUsername());
+    public List<OrderResponse> getOrders(@RequestBody Long memberId) {
+        return orderService.getOrders(memberId);
     }
 }

--- a/src/main/java/com/tutti/server/core/order/api/OrderApi.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApi.java
@@ -2,8 +2,13 @@ package com.tutti.server.core.order.api;
 
 import com.tutti.server.core.order.application.OrderService;
 import com.tutti.server.core.order.payload.request.OrderCreateRequest;
+import com.tutti.server.core.order.payload.response.OrderResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,4 +27,10 @@ public class OrderApi implements OrderApiSpec {
         orderService.createOrder(request);
     }
 
+    // 주문 전체 조회
+    @Override
+    @GetMapping
+    public List<OrderResponse> getOrders(@AuthenticationPrincipal UserDetails user) {
+        return orderService.getOrders(user.getUsername());
+    }
 }

--- a/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
@@ -1,12 +1,18 @@
 package com.tutti.server.core.order.api;
 
 import com.tutti.server.core.order.payload.request.OrderCreateRequest;
+import com.tutti.server.core.order.payload.response.OrderResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Tag(name = "주문 API")
 public interface OrderApiSpec {
 
     @Operation(summary = "주문 생성")
     void createOrder(OrderCreateRequest request);
+
+    @Operation(summary = "주문 내역 전체 조회")
+    List<OrderResponse> getOrders(UserDetails user);
 }

--- a/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
@@ -5,7 +5,6 @@ import com.tutti.server.core.order.payload.response.OrderResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import org.springframework.security.core.userdetails.UserDetails;
 
 @Tag(name = "주문 API")
 public interface OrderApiSpec {
@@ -14,5 +13,5 @@ public interface OrderApiSpec {
     void createOrder(OrderCreateRequest request);
 
     @Operation(summary = "주문 내역 전체 조회")
-    List<OrderResponse> getOrders(UserDetails user);
+    List<OrderResponse> getOrders(Long memberId);
 }

--- a/src/main/java/com/tutti/server/core/order/application/OrderService.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderService.java
@@ -25,5 +25,5 @@ public interface OrderService {
 
     ProductItem findProductItemById(List<ProductItem> productItems, Long productItemId);
 
-    List<OrderResponse> getOrders(String email);
+    List<OrderResponse> getOrders(Long memberId);
 }

--- a/src/main/java/com/tutti/server/core/order/application/OrderService.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderService.java
@@ -3,6 +3,7 @@ package com.tutti.server.core.order.application;
 import com.tutti.server.core.order.domain.Order;
 import com.tutti.server.core.order.domain.OrderItem;
 import com.tutti.server.core.order.payload.request.OrderCreateRequest;
+import com.tutti.server.core.order.payload.response.OrderResponse;
 import com.tutti.server.core.product.domain.ProductItem;
 import java.util.List;
 
@@ -23,4 +24,6 @@ public interface OrderService {
             List<ProductItem> productItems);
 
     ProductItem findProductItemById(List<ProductItem> productItems, Long productItemId);
+
+    List<OrderResponse> getOrders(String email);
 }

--- a/src/main/java/com/tutti/server/core/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderServiceImpl.java
@@ -10,6 +10,7 @@ import com.tutti.server.core.order.infrastructure.OrderHistoryRepository;
 import com.tutti.server.core.order.infrastructure.OrderItemRepository;
 import com.tutti.server.core.order.infrastructure.OrderRepository;
 import com.tutti.server.core.order.payload.request.OrderCreateRequest;
+import com.tutti.server.core.order.payload.response.OrderResponse;
 import com.tutti.server.core.product.domain.ProductItem;
 import com.tutti.server.core.product.infrastructure.ProductItemRepository;
 import com.tutti.server.core.support.exception.DomainException;
@@ -125,5 +126,15 @@ public class OrderServiceImpl implements OrderService {
                 .filter(item -> item.getId().equals(productItemId))
                 .findFirst()
                 .orElseThrow(() -> new DomainException(ExceptionType.PRODUCT_MISMATCH));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OrderResponse> getOrders(String email) {
+        return orderRepository.findAllByMemberEmailAndDeleteStatusFalse(email)
+                .stream()
+                .map(order -> OrderResponse.fromEntity(order,
+                        orderItemRepository.findAllByOrderId(order.getId())))
+                .toList();
     }
 }

--- a/src/main/java/com/tutti/server/core/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderServiceImpl.java
@@ -130,8 +130,8 @@ public class OrderServiceImpl implements OrderService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<OrderResponse> getOrders(String email) {
-        return orderRepository.findAllByMemberEmailAndDeleteStatusFalse(email)
+    public List<OrderResponse> getOrders(Long memberId) {
+        return orderRepository.findAllByMemberIdAndDeleteStatusFalse(memberId)
                 .stream()
                 .map(order -> OrderResponse.fromEntity(order,
                         orderItemRepository.findAllByOrderId(order.getId())))

--- a/src/main/java/com/tutti/server/core/order/domain/Order.java
+++ b/src/main/java/com/tutti/server/core/order/domain/Order.java
@@ -38,7 +38,7 @@ public class Order extends BaseEntity {
     private int orderCount;
     private int deliveryFee;
     private int totalAmount;
-    private LocalDateTime completed_at;
+    private LocalDateTime completedAt;
 
 
     @Builder

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderItemRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderItemRepository.java
@@ -3,6 +3,7 @@ package com.tutti.server.core.order.infrastructure;
 import com.tutti.server.core.order.domain.OrderItem;
 import com.tutti.server.core.support.exception.DomainException;
 import com.tutti.server.core.support.exception.ExceptionType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
@@ -11,5 +12,7 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
         return findById(id)
                 .orElseThrow(() -> new DomainException(ExceptionType.ORDER_ITEM_NOT_FOUND));
     }
+
+    List<OrderItem> findAllByOrderId(Long orderId);
 
 }

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
@@ -3,6 +3,7 @@ package com.tutti.server.core.order.infrastructure;
 import com.tutti.server.core.order.domain.Order;
 import com.tutti.server.core.support.exception.DomainException;
 import com.tutti.server.core.support.exception.ExceptionType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,4 +15,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     }
 
     Optional<Order> findByOrderNumber(String orderNumber);
+
+    List<Order> findAllByMemberEmailAndDeleteStatusFalse(String email);
 }

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
@@ -16,5 +16,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findByOrderNumber(String orderNumber);
 
-    List<Order> findAllByMemberEmailAndDeleteStatusFalse(String email);
+    List<Order> findAllByMemberIdAndDeleteStatusFalse(Long memberId);
 }

--- a/src/main/java/com/tutti/server/core/order/payload/response/OrderResponse.java
+++ b/src/main/java/com/tutti/server/core/order/payload/response/OrderResponse.java
@@ -1,0 +1,55 @@
+package com.tutti.server.core.order.payload.response;
+
+import com.tutti.server.core.order.domain.Order;
+import com.tutti.server.core.order.domain.OrderItem;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record OrderResponse(
+        String orderNumber,
+        LocalDateTime orderDate,
+        int totalAmount,
+        String orderStatus,
+        List<OrderItemSummary> orderItems
+) {
+
+    // 주문 정보를 추출하는 메서드
+    public static OrderResponse fromEntity(Order order, List<OrderItem> orderItems) {
+        List<OrderItemSummary> itemSummaries = orderItems.stream()
+                .map(OrderItemSummary::fromEntity)
+                .toList();
+
+        return OrderResponse.builder()
+                .orderNumber(order.getOrderNumber())
+                .orderDate(order.getCompletedAt())
+                .totalAmount(order.getTotalAmount())
+                .orderStatus(order.getOrderStatus())
+                .orderItems(itemSummaries)
+                .build();
+    }
+
+    @Builder
+    public record OrderItemSummary(
+            String productName,
+            String productImgUrl,
+            String productOptionName,
+            String productOptionValue,
+            int quantity,
+            int price
+    ) {
+
+        // 상품 정보를 추출하는 메서드
+        public static OrderItemSummary fromEntity(OrderItem orderItem) {
+            return OrderItemSummary.builder()
+                    .productName(orderItem.getProductName())
+                    .productImgUrl(orderItem.getProductImgUrl())
+                    .productOptionName(orderItem.getProductOptionName())
+                    .productOptionValue(orderItem.getProductOptionValue())
+                    .quantity(orderItem.getQuantity())
+                    .price(orderItem.getPrice())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #104 

---

### 🚀 어떤 기능을 구현했나요 ?
1. (READ) 유저는 주문한 상품의 내역을 확인할 수 있다.
2. 유저가 주문 내역 api를 요청하면 delete_status=false 인 내역만 반환한다.
3. response: order List
주문번호/주문한 날짜/총 결제 금액
상품 이미지/주문한 상품명/옵션/수량/가격
예상 도착일(배송 도착 전 상품들만)

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

