### PR TITLE
[BE] feat: 장바구니 조회 기능 수정

### DIFF
--- a/src/main/java/com/tutti/server/core/cart/api/CartApi.java
+++ b/src/main/java/com/tutti/server/core/cart/api/CartApi.java
@@ -3,9 +3,11 @@ package com.tutti.server.core.cart.api;
 import com.tutti.server.core.cart.application.CartService;
 import com.tutti.server.core.cart.payload.request.CartItemCreateRequest;
 import com.tutti.server.core.cart.payload.response.CartItemsResponse;
+import com.tutti.server.core.member.application.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,20 +25,21 @@ public class CartApi implements CartApiSpec {
 
     @Override
     @PostMapping
-    public void addCartItem(@RequestBody @Valid CartItemCreateRequest request) {
-        cartService.addCartItem(request);
+    public void addCartItem(@AuthenticationPrincipal CustomUserDetails user,
+            @RequestBody @Valid CartItemCreateRequest request) {
+        cartService.addCartItem(user.getMemberId(), request);
     }
 
     @Override
     @GetMapping
-    public List<CartItemsResponse> getCartItems(@RequestBody Long memberId) {
-        return cartService.getCartItems(memberId);
+    public List<CartItemsResponse> getCartItems(@AuthenticationPrincipal CustomUserDetails user) {
+        return cartService.getCartItems(user.getMemberId());
     }
 
     @Override
     @PatchMapping("/{cartItemId}")
-    public void removeCartItem(@PathVariable("cartItemId") Long cartItemId,
-            @RequestBody Long memberId) {
-        cartService.removeCartItem(cartItemId, memberId);
+    public void removeCartItem(@AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable("cartItemId") Long cartItemId) {
+        cartService.removeCartItem(user.getMemberId(), cartItemId);
     }
 }

--- a/src/main/java/com/tutti/server/core/cart/api/CartApiSpec.java
+++ b/src/main/java/com/tutti/server/core/cart/api/CartApiSpec.java
@@ -4,6 +4,7 @@ import com.tutti.server.core.cart.payload.request.CartItemCreateRequest;
 import com.tutti.server.core.cart.payload.response.CartItemsResponse;
 import com.tutti.server.core.member.application.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -19,5 +20,6 @@ public interface CartApiSpec {
     List<CartItemsResponse> getCartItems(CustomUserDetails user);
 
     @Operation(summary = "장바구니 상품 삭제")
-    void removeCartItem(CustomUserDetails user, Long cartItemId);
+    void removeCartItem(CustomUserDetails user,
+            @Parameter(description = "삭제할 장바구니 상품 id", example = "1") Long cartItemId);
 }

--- a/src/main/java/com/tutti/server/core/cart/api/CartApiSpec.java
+++ b/src/main/java/com/tutti/server/core/cart/api/CartApiSpec.java
@@ -2,19 +2,22 @@ package com.tutti.server.core.cart.api;
 
 import com.tutti.server.core.cart.payload.request.CartItemCreateRequest;
 import com.tutti.server.core.cart.payload.response.CartItemsResponse;
+import com.tutti.server.core.member.application.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
 @Tag(name = "장바구니 API")
+@SecurityRequirement(name = "Bearer Authentication")
 public interface CartApiSpec {
 
     @Operation(summary = "장바구니 상품 추가")
-    void addCartItem(CartItemCreateRequest request);
+    void addCartItem(CustomUserDetails user, CartItemCreateRequest request);
 
     @Operation(summary = "장바구니 상품 조회")
-    List<CartItemsResponse> getCartItems(Long memberId);
+    List<CartItemsResponse> getCartItems(CustomUserDetails user);
 
     @Operation(summary = "장바구니 상품 삭제")
-    void removeCartItem(Long cartItemId, Long memberId);
+    void removeCartItem(CustomUserDetails user, Long cartItemId);
 }

--- a/src/main/java/com/tutti/server/core/cart/application/CartService.java
+++ b/src/main/java/com/tutti/server/core/cart/application/CartService.java
@@ -6,11 +6,11 @@ import java.util.List;
 
 public interface CartService {
 
-    void addCartItem(CartItemCreateRequest request);
+    void addCartItem(Long memberId, CartItemCreateRequest request);
 
-    void createCartItem(CartItemCreateRequest request);
+    void createCartItem(Long memberId, CartItemCreateRequest request);
 
     List<CartItemsResponse> getCartItems(Long memberId);
 
-    void removeCartItem(Long cartItemId, Long memberId);
+    void removeCartItem(Long memberId, Long cartItemId);
 }

--- a/src/main/java/com/tutti/server/core/cart/application/CartServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/cart/application/CartServiceImpl.java
@@ -25,20 +25,20 @@ public class CartServiceImpl implements CartService {
     @Override
     @Transactional
     // 기존 장바구니 상품이 있는지 확인하고, 없으면 새로 생성하는 메서드
-    public void addCartItem(CartItemCreateRequest request) {
-        cartItemRepository.findByMemberIdAndProductItemIdAndDeleteStatusFalse(request.memberId(),
+    public void addCartItem(Long memberId, CartItemCreateRequest request) {
+        cartItemRepository.findByMemberIdAndProductItemIdAndDeleteStatusFalse(memberId,
                         request.productItemId())
                 // 이미 장바구니에 해당 상품이 있다면 수량만 업데이트
                 .ifPresentOrElse(item -> item.changeQuantity(request.quantity()),
                         // 없다면 장바구니에 상품을 새로 생성하여 저장
-                        () -> createCartItem(request));
+                        () -> createCartItem(memberId, request));
     }
 
     @Override
     @Transactional
     // 장바구니 상품을 엔티티로 저장하는 메서드
-    public void createCartItem(CartItemCreateRequest request) {
-        var member = memberRepository.findOne(request.memberId());
+    public void createCartItem(Long memberId, CartItemCreateRequest request) {
+        var member = memberRepository.findOne(memberId);
         var productItem = productItemRepository.findOne(request.productItemId());
 
         // 장바구니 상품 엔티티를 만들 때, 수량도 받아야 하기 때문에 파라미터로 request 가 필요하다
@@ -56,8 +56,8 @@ public class CartServiceImpl implements CartService {
 
     @Override
     @Transactional
-    public void removeCartItem(Long cartItemId, Long memberId) {
-        cartItemRepository.findByIdAndMemberIdAndDeleteStatusFalse(cartItemId, memberId)
+    public void removeCartItem(Long memberId, Long cartItemId) {
+        cartItemRepository.findByMemberIdAndIdAndDeleteStatusFalse(memberId, cartItemId)
                 .ifPresentOrElse(BaseEntity::delete,
                         () -> {
                             throw new DomainException(ExceptionType.UNAUTHORIZED_ERROR);

--- a/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
+++ b/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
@@ -14,7 +14,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
                 .orElseThrow(() -> new DomainException(ExceptionType.CART_ITEM_NOT_FOUND));
     }
 
-    Optional<CartItem> findByMemberIdAndIdAndDeleteStatusFalse(Long memberId, Long cartItemId);
+    Optional<CartItem> findByMemberIdAndCartItemIdAndDeleteStatusFalse(Long memberId, Long cartItemId);
 
     Optional<CartItem> findByMemberIdAndProductItemIdAndDeleteStatusFalse(Long memberId,
             Long productItemId);

--- a/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
+++ b/src/main/java/com/tutti/server/core/cart/infrastructure/CartItemRepository.java
@@ -14,7 +14,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
                 .orElseThrow(() -> new DomainException(ExceptionType.CART_ITEM_NOT_FOUND));
     }
 
-    Optional<CartItem> findByIdAndMemberIdAndDeleteStatusFalse(Long cartItemId, Long memberId);
+    Optional<CartItem> findByMemberIdAndIdAndDeleteStatusFalse(Long memberId, Long cartItemId);
 
     Optional<CartItem> findByMemberIdAndProductItemIdAndDeleteStatusFalse(Long memberId,
             Long productItemId);

--- a/src/main/java/com/tutti/server/core/cart/payload/request/CartItemCreateRequest.java
+++ b/src/main/java/com/tutti/server/core/cart/payload/request/CartItemCreateRequest.java
@@ -11,8 +11,6 @@ import lombok.Builder;
 @Builder
 public record CartItemCreateRequest(
 
-        Long memberId,
-
         @NotNull(message = "필수 옵션을 선택해주세요.")
         Long productItemId,
 

--- a/src/main/java/com/tutti/server/core/cart/payload/response/CartItemsResponse.java
+++ b/src/main/java/com/tutti/server/core/cart/payload/response/CartItemsResponse.java
@@ -27,6 +27,7 @@ public record CartItemsResponse(
         return CartItemsResponse.builder()
                 .cartItemId(cartItem.getId())
                 .storeName(cartItem.getProductItem().getProduct().getStoreId().getName())
+                .productId(cartItem.getProductItem().getProduct().getId())
                 .productItemName(cartItem.getProductName())
                 .productImgUrl(cartItem.getProductImgUrl())
                 .firstOptionName(cartItem.getFirstOptionName())

--- a/src/main/java/com/tutti/server/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tutti/server/global/config/SwaggerConfig.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -19,8 +18,7 @@ import org.springframework.context.annotation.Configuration;
                 version = "1.0",
                 description = "Tutti MarketPlace API",
                 contact = @Contact(name = "관리자", email = "tutti.service.center@gmail.com")
-        ),
-        security = @SecurityRequirement(name = "Bearer Authentication")
+        )
 )
 @SecurityScheme(
         name = "Bearer Authentication",
@@ -38,7 +36,6 @@ public class SwaggerConfig {
                 .components(new Components()
                         .addSecuritySchemes("Bearer Authentication",
                                 new io.swagger.v3.oas.models.security.SecurityScheme()
-                                        .name("Bearer Authentication")
                                         .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
                                         .scheme("bearer")
                                         .bearerFormat("JWT")

--- a/src/main/java/com/tutti/server/global/config/SwaggerConfig.java
+++ b/src/main/java/com/tutti/server/global/config/SwaggerConfig.java
@@ -6,9 +6,6 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
@@ -24,22 +21,10 @@ import org.springframework.context.annotation.Configuration;
         name = "Bearer Authentication",
         type = SecuritySchemeType.HTTP,
         bearerFormat = "JWT",
-        scheme = "bearer",
+        scheme = "Bearer",
         in = SecuritySchemeIn.HEADER,
         description = "Bearer token authentication"
 )
 public class SwaggerConfig {
 
-    @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI()
-                .components(new Components()
-                        .addSecuritySchemes("Bearer Authentication",
-                                new io.swagger.v3.oas.models.security.SecurityScheme()
-                                        .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
-                                        .scheme("bearer")
-                                        .bearerFormat("JWT")
-                                        .in(io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER)
-                                        .description("Bearer token authentication")));
-    }
 }


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #260 

---

### 🚀 어떤 기능을 구현했나요 ?
1. 장바구니 엔티티 필드 추가
2. 장바구니 조회 응답 DTO 필드 추가 스토어명,
상품ID,
optionName1: 사이즈,
optionValue1: S,
optionName1: 색상,
optionValue1: BLU,
원가,
판매가,
최대 구매 수량
3. 장바구니 조회 기능 인가 적용
4. 스웨거 설정도 스을쩍 바꾼다,, (전역 보안 사항 적용 -> 특정 API 만 적용되도록 security 필드 제거)

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

