### PR TITLE
[BE] feat: 주문 삭제 API 기능 구현

### DIFF
--- a/src/main/java/com/tutti/server/core/order/api/OrderApi.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApi.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +41,12 @@ public class OrderApi implements OrderApiSpec {
     public OrderDetailResponse getOrderDetail(@AuthenticationPrincipal CustomUserDetails user,
             @PathVariable Long orderId) {
         return orderService.getOrderDetail(orderId);
+    }
+
+    @Override
+    @PatchMapping("/{orderId}")
+    public void deleteOrder(@AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long orderId) {
+        orderService.deleteOrder(user.getMemberId(), orderId);
     }
 }

--- a/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
@@ -21,4 +21,8 @@ public interface OrderApiSpec {
     @Operation(summary = "주문 내역 상세 조회")
     OrderDetailResponse getOrderDetail(CustomUserDetails user,
             @Parameter(description = "조회할 주문 id", example = "1") Long orderId);
+
+    @Operation(summary = "주문 내역 삭제")
+    void deleteOrder(CustomUserDetails user,
+            @Parameter(description = "삭제할 주문 id", example = "1") Long orderId);
 }

--- a/src/main/java/com/tutti/server/core/order/application/OrderService.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderService.java
@@ -41,4 +41,6 @@ public interface OrderService {
     List<OrderResponse> getOrders(Long memberId);
 
     OrderDetailResponse getOrderDetail(Long orderId);
+
+    void deleteOrder(Long memberId, Long orderId);
 }

--- a/src/main/java/com/tutti/server/core/order/application/OrderServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderServiceImpl.java
@@ -14,6 +14,7 @@ import com.tutti.server.core.order.payload.response.OrderDetailResponse;
 import com.tutti.server.core.order.payload.response.OrderResponse;
 import com.tutti.server.core.product.domain.ProductItem;
 import com.tutti.server.core.product.infrastructure.ProductItemRepository;
+import com.tutti.server.core.support.entity.BaseEntity;
 import com.tutti.server.core.support.exception.DomainException;
 import com.tutti.server.core.support.exception.ExceptionType;
 import java.time.LocalDateTime;
@@ -208,5 +209,15 @@ public class OrderServiceImpl implements OrderService {
         List<OrderItem> orderItems = orderItemRepository.findAllByOrderId(orderId);
 
         return OrderDetailResponse.fromEntity(order, orderItems);
+    }
+
+    @Override
+    @Transactional
+    public void deleteOrder(Long memberId, Long orderId) {
+        orderRepository.findByMemberIdAndIdAndDeleteStatusFalse(memberId, orderId)
+                .ifPresentOrElse(BaseEntity::delete,
+                        () -> {
+                            throw new DomainException(ExceptionType.UNAUTHORIZED_ERROR);
+                        });
     }
 }

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
@@ -17,4 +17,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderNumber(String orderNumber);
 
     List<Order> findAllByMemberIdAndDeleteStatusFalse(Long memberId);
+
+    Optional<Order> findByMemberIdAndIdAndDeleteStatusFalse(Long memberId, Long orderId);
 }


### PR DESCRIPTION


<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #323 

---

### 🚀 어떤 기능을 구현했나요 ?
1. 유저가 주문 내역 삭제(버튼) api를 요청하면, delete_status=true 로 업데이트한다.
2. response: 없다.
3. request: member.id(member의 인증 정보), orderId
4. 해당 상품의 delete_status=true로 update 한다.

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

