### PR TITLE
[BE] feat: 주문 생성 API와 결제 생성 API 합치기

### DIFF
--- a/src/main/java/com/tutti/server/core/order/api/OrderApi.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApi.java
@@ -2,7 +2,6 @@ package com.tutti.server.core.order.api;
 
 import com.tutti.server.core.member.application.CustomUserDetails;
 import com.tutti.server.core.order.application.OrderService;
-import com.tutti.server.core.order.payload.request.OrderCreateRequest;
 import com.tutti.server.core.order.payload.request.OrderPageRequest;
 import com.tutti.server.core.order.payload.response.OrderDetailResponse;
 import com.tutti.server.core.order.payload.response.OrderPageResponse;
@@ -32,13 +31,6 @@ public class OrderApi implements OrderApiSpec {
     @PostMapping("/checkout")
     public OrderPageResponse getOrderPage(@Valid @RequestBody OrderPageRequest request) {
         return orderService.getOrderPage(request);
-    }
-
-    @Override
-    @PostMapping
-    public void createOrder(@Valid @RequestBody OrderCreateRequest request,
-            @AuthenticationPrincipal CustomUserDetails user) {
-        orderService.createOrder(request, user.getMemberId());
     }
 
     @Override

--- a/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
+++ b/src/main/java/com/tutti/server/core/order/api/OrderApiSpec.java
@@ -1,7 +1,6 @@
 package com.tutti.server.core.order.api;
 
 import com.tutti.server.core.member.application.CustomUserDetails;
-import com.tutti.server.core.order.payload.request.OrderCreateRequest;
 import com.tutti.server.core.order.payload.request.OrderPageRequest;
 import com.tutti.server.core.order.payload.response.OrderDetailResponse;
 import com.tutti.server.core.order.payload.response.OrderPageResponse;
@@ -11,14 +10,11 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 
-@Tag(name = "Order", description = "주문 관련 API")
+@Tag(name = "Orders", description = "주문 관련 API")
 public interface OrderApiSpec {
 
     @Operation(summary = "주문서 작성 페이지")
     OrderPageResponse getOrderPage(OrderPageRequest request);
-
-    @Operation(summary = "주문 생성")
-    void createOrder(OrderCreateRequest request, CustomUserDetails user);
 
     @Operation(summary = "주문 내역 전체 조회")
     List<OrderResponse> getOrders(CustomUserDetails user);

--- a/src/main/java/com/tutti/server/core/order/application/OrderService.java
+++ b/src/main/java/com/tutti/server/core/order/application/OrderService.java
@@ -1,7 +1,7 @@
 package com.tutti.server.core.order.application;
 
+import com.tutti.server.core.order.domain.CreatedByType;
 import com.tutti.server.core.order.domain.Order;
-import com.tutti.server.core.order.domain.OrderItem;
 import com.tutti.server.core.order.payload.request.OrderCreateRequest;
 import com.tutti.server.core.order.payload.request.OrderItemRequest;
 import com.tutti.server.core.order.payload.request.OrderPageRequest;
@@ -9,6 +9,7 @@ import com.tutti.server.core.order.payload.response.OrderDetailResponse;
 import com.tutti.server.core.order.payload.response.OrderItemResponse;
 import com.tutti.server.core.order.payload.response.OrderPageResponse;
 import com.tutti.server.core.order.payload.response.OrderResponse;
+import com.tutti.server.core.payment.payload.request.PaymentRequest;
 import com.tutti.server.core.product.domain.ProductItem;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -18,35 +19,30 @@ public interface OrderService {
     OrderPageResponse getOrderPage(OrderPageRequest request);
 
     List<OrderItemResponse> createOrderItemResponses(
-            List<OrderItemRequest> requests,
-            List<ProductItem> productItems);
+            List<OrderItemRequest> requests);
 
-    void createOrder(OrderCreateRequest request, Long memberId);
+    void validateProductItems(List<OrderItemRequest> requests);
+
+    int calculateTotalProductAmount(
+            List<OrderItemRequest> requests);
+
+    int calculateTotalDiscountAmount(
+            List<OrderItemRequest> requests);
+
+    int calculateOrderTotal(
+            List<OrderItemRequest> requests,
+            BiFunction<ProductItem, Integer, Integer> calculator);
+
+    PaymentRequest createOrder(OrderCreateRequest request, Long memberId);
 
     String generateOrderNumber();
 
     String generateOrderName(OrderCreateRequest request);
 
-    List<ProductItem> getProductItems(List<OrderItemRequest> requests);
+    void createOrderItems(Order order,
+            List<OrderItemRequest> requests);
 
-    int calculateTotalProductAmount(
-            List<OrderItemRequest> requests,
-            List<ProductItem> productItems);
-
-    int calculateTotalDiscountAmount(
-            List<OrderItemRequest> requests,
-            List<ProductItem> productItems);
-
-    int calculateOrderTotal(
-            List<OrderItemRequest> requests,
-            List<ProductItem> productItems,
-            BiFunction<ProductItem, Integer, Integer> calculator);
-
-    List<OrderItem> createOrderItems(Order order,
-            List<OrderItemRequest> requests,
-            List<ProductItem> productItems);
-
-    ProductItem findProductItemById(List<ProductItem> productItems, Long productItemId);
+    void createOrderHistory(Order order, CreatedByType createdByType, long createdById);
 
     List<OrderResponse> getOrders(Long memberId);
 

--- a/src/main/java/com/tutti/server/core/order/domain/Order.java
+++ b/src/main/java/com/tutti/server/core/order/domain/Order.java
@@ -84,10 +84,13 @@ public class Order extends BaseEntity {
         this.deliveredAt = deliveredAt;
     }
 
+    public void updateOrderStatus(String orderStatus) {
+        this.orderStatus = orderStatus;
+    }
+
     public void updateCompletedAt(LocalDateTime completed) {
         this.paidAt = completed;
     }
-
 
     public void updatePaidAt(LocalDateTime paid) {
         this.paidAt = paid;

--- a/src/main/java/com/tutti/server/core/order/domain/OrderStatus.java
+++ b/src/main/java/com/tutti/server/core/order/domain/OrderStatus.java
@@ -2,11 +2,8 @@ package com.tutti.server.core.order.domain;
 
 public enum OrderStatus {
 
-    WAITING_FOR_PAYMENT,         // 결제 대기
     WAITING_CANCELED,            // 결제 대기 취소
-
     ORDER_RECEIVED,              // 주문 접수
-
     ORDER_COMPLETED              // 구매 확정
 
 }

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderHistoryRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderHistoryRepository.java
@@ -3,7 +3,10 @@ package com.tutti.server.core.order.infrastructure;
 import com.tutti.server.core.order.domain.OrderHistory;
 import com.tutti.server.core.support.exception.DomainException;
 import com.tutti.server.core.support.exception.ExceptionType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OrderHistoryRepository extends JpaRepository<OrderHistory, Long> {
 
@@ -12,4 +15,12 @@ public interface OrderHistoryRepository extends JpaRepository<OrderHistory, Long
                 .orElseThrow(() -> new DomainException(ExceptionType.ORDER_HISTORY_NOT_FOUND));
     }
 
+    // 주문 ID로 최신 이력 찾기
+    Optional<OrderHistory> findByOrderIdAndLatestVersionTrue(Long orderId);
+
+    // 주문 ID로 모든 이력 중 latestVersion이 true인 것을 false로 업데이트
+    @Modifying
+    @Query("UPDATE OrderHistory oh SET oh.latestVersion = false "
+            + "WHERE oh.order.id = :orderId AND oh.latestVersion = true")
+    void updatePreviousVersions(Long orderId);
 }

--- a/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
+++ b/src/main/java/com/tutti/server/core/order/infrastructure/OrderRepository.java
@@ -16,8 +16,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     boolean existsByIdAndDeleteStatusFalse(Long orderId);
 
-    Optional<Order> findByOrderNumber(String orderNumber);
-
     List<Order> findAllByMemberIdAndDeleteStatusFalse(Long memberId);
 
     Optional<Order> findByIdAndMemberIdAndDeleteStatusFalse(Long orderId, Long memberId);

--- a/src/main/java/com/tutti/server/core/order/payload/request/OrderCreateRequest.java
+++ b/src/main/java/com/tutti/server/core/order/payload/request/OrderCreateRequest.java
@@ -1,9 +1,7 @@
 package com.tutti.server.core.order.payload.request;
 
 import com.tutti.server.core.member.domain.Member;
-import com.tutti.server.core.order.domain.CreatedByType;
 import com.tutti.server.core.order.domain.Order;
-import com.tutti.server.core.order.domain.OrderHistory;
 import com.tutti.server.core.payment.domain.PaymentMethodType;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -12,10 +10,14 @@ import lombok.Builder;
 @Builder
 public record OrderCreateRequest(
 
-        @NotNull(message = "주문할 상품을 선택해주세요.")
-        List<OrderItemRequest> orderItems,
+        int totalDiscountAmount,
+        int totalProductAmount,
+        int deliveryFee,
+        int totalAmount,
+        PaymentMethodType paymentType,
 
-        PaymentMethodType paymentType
+        @NotNull(message = "주문할 상품을 선택해주세요.")
+        List<OrderItemRequest> orderItems
 ) {
 
     public Order toEntity(Member member, String orderStatus, String orderNumber, String orderName,
@@ -33,18 +35,6 @@ public record OrderCreateRequest(
                 .totalProductAmount(totalProductAmount)
                 .deliveryFee(deliveryFee)
                 .totalAmount(totalAmount)
-                .build();
-    }
-
-    public OrderHistory toEntity(Order order, String orderStatus, CreatedByType createdByType,
-            long createdById
-    ) {
-        return OrderHistory.builder()
-                .order(order)
-                .orderStatus(orderStatus)
-                .createdByType(createdByType)
-                .createdById(createdById)
-                .latestVersion(true)
                 .build();
     }
 }

--- a/src/main/java/com/tutti/server/core/payment/api/PaymentApi.java
+++ b/src/main/java/com/tutti/server/core/payment/api/PaymentApi.java
@@ -1,19 +1,18 @@
 package com.tutti.server.core.payment.api;
 
 import com.tutti.server.core.member.application.CustomUserDetails;
+import com.tutti.server.core.order.application.OrderService;
+import com.tutti.server.core.order.payload.request.OrderCreateRequest;
 import com.tutti.server.core.payment.application.PaymentCancelService;
 import com.tutti.server.core.payment.application.PaymentService;
 import com.tutti.server.core.payment.application.PaymentViewService;
 import com.tutti.server.core.payment.payload.request.PaymentCancelRequest;
 import com.tutti.server.core.payment.payload.request.PaymentConfirmRequest;
 import com.tutti.server.core.payment.payload.request.PaymentRequest;
-import com.tutti.server.core.payment.payload.response.PaymentResponse;
 import com.tutti.server.core.payment.payload.response.PaymentViewResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,25 +22,25 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@CrossOrigin(origins = "http://127.0.0.1:5500") // 프론트엔드 주소
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/payments")
+@CrossOrigin(origins = "http://127.0.0.1:5500") // 프론트엔드 주소
 @SecurityRequirement(name = "Bearer Authentication")  // 컨트롤러 전체에 적용
 public class PaymentApi implements PaymentApiSpec {
 
+    private final OrderService orderService;
     private final PaymentService paymentService;
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final PaymentViewService paymentViewService;
     private final PaymentCancelService paymentCancelService;
 
-    private final PaymentViewService paymentViewService;
-
-    @PostMapping("/request")
-    public PaymentResponse requestPayment(
-            @Valid @RequestBody PaymentRequest request,
+    @PostMapping
+    public void requestPayment(
+            @Valid @RequestBody OrderCreateRequest request,
             @AuthenticationPrincipal CustomUserDetails user) {
+        PaymentRequest paymentRequest = orderService.createOrder(request, user.getMemberId());
 
-        return paymentService.requestPayment(request, user.getMemberId());
+        paymentService.requestPayment(paymentRequest, user.getMemberId());
     }
 
     @PostMapping("/confirm/success")

--- a/src/main/java/com/tutti/server/core/payment/api/PaymentApiSpec.java
+++ b/src/main/java/com/tutti/server/core/payment/api/PaymentApiSpec.java
@@ -1,19 +1,18 @@
 package com.tutti.server.core.payment.api;
 
 import com.tutti.server.core.member.application.CustomUserDetails;
+import com.tutti.server.core.order.payload.request.OrderCreateRequest;
 import com.tutti.server.core.payment.payload.request.PaymentCancelRequest;
 import com.tutti.server.core.payment.payload.request.PaymentConfirmRequest;
-import com.tutti.server.core.payment.payload.request.PaymentRequest;
-import com.tutti.server.core.payment.payload.response.PaymentResponse;
 import com.tutti.server.core.payment.payload.response.PaymentViewResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "결제 API", description = "결제 요청을 처리하는 API")
+@Tag(name = "Payments", description = "결제 관련 API")
 public interface PaymentApiSpec {
 
-    @Operation(summary = "결제 요청", description = "사용자가 결제를 요청하는 API")
-    PaymentResponse requestPayment(PaymentRequest request, CustomUserDetails user);
+    @Operation(summary = "주문/결제 요청", description = "사용자가 주문을 완료하고, 결제를 요청하는 API")
+    void requestPayment(OrderCreateRequest request, CustomUserDetails user);
 
     @Operation(summary = "결제 승인", description = "사용자가 결제 승인을 요청하는 API")
     void confirmPayment(PaymentConfirmRequest request, CustomUserDetails user);

--- a/src/main/java/com/tutti/server/core/payment/application/PaymentCancelServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/payment/application/PaymentCancelServiceImpl.java
@@ -1,6 +1,9 @@
 package com.tutti.server.core.payment.application;
 
+import com.tutti.server.core.order.application.OrderService;
+import com.tutti.server.core.order.domain.CreatedByType;
 import com.tutti.server.core.order.domain.Order;
+import com.tutti.server.core.order.infrastructure.OrderHistoryRepository;
 import com.tutti.server.core.order.infrastructure.OrderRepository;
 import com.tutti.server.core.payment.domain.Payment;
 import com.tutti.server.core.payment.domain.PaymentStatus;
@@ -25,6 +28,8 @@ public class PaymentCancelServiceImpl implements PaymentCancelService {
     private final TossPaymentService tossPaymentService;
     private final RefundRepository refundRepository;
     private final OrderRepository orderRepository;
+    private final OrderService orderService;
+    private final OrderHistoryRepository orderHistoryRepository;
 
     @Override
     @Transactional
@@ -49,6 +54,10 @@ public class PaymentCancelServiceImpl implements PaymentCancelService {
         // 결제 상태 업데이트 및 결제 이력 저장
         updatePaymentStatus(payment);
         paymentHistoryService.savePaymentHistory(payment);
+
+        // 주문 상태 업데이트 및 주문 이력 생성
+        order.updateOrderStatus(PaymentStatus.CANCELED.name());
+        orderService.createOrderHistory(order, CreatedByType.MEMBER, authMemberId);
 
         return payment;
     }

--- a/src/main/java/com/tutti/server/core/payment/application/PaymentServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/payment/application/PaymentServiceImpl.java
@@ -1,7 +1,10 @@
 package com.tutti.server.core.payment.application;
 
 
+import com.tutti.server.core.order.application.OrderService;
+import com.tutti.server.core.order.domain.CreatedByType;
 import com.tutti.server.core.order.domain.Order;
+import com.tutti.server.core.order.infrastructure.OrderHistoryRepository;
 import com.tutti.server.core.order.infrastructure.OrderRepository;
 import com.tutti.server.core.payment.domain.Payment;
 import com.tutti.server.core.payment.domain.PaymentStatus;
@@ -12,6 +15,7 @@ import com.tutti.server.core.payment.payload.response.ParsedTossApiResponse;
 import com.tutti.server.core.payment.payload.response.PaymentResponse;
 import com.tutti.server.core.support.exception.DomainException;
 import com.tutti.server.core.support.exception.ExceptionType;
+import java.time.LocalDateTime;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,19 +27,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class PaymentServiceImpl implements PaymentService {
 
-    private final PaymentRepository paymentRepository;
     private final OrderRepository orderRepository;
+    private final OrderService orderService;
+    private final PaymentRepository paymentRepository;
     private final TossPaymentService tossPaymentService;
     private final PaymentHistoryService paymentHistoryService;
+    private final OrderHistoryRepository orderHistoryRepository;
 
     //1. 결제 요청
     @Override
     @Transactional
     public PaymentResponse requestPayment(PaymentRequest request, Long authMemberId) {
-
-        Order order = getValidOrder(request.orderId(), authMemberId);
+        Order order = getValidOrder(request.orderNumber(), authMemberId);
         validateOrderAmountAndName(order, request);
         Payment payment = validateOrReusePayment(order, request);
+
         return PaymentResponse.fromEntity(payment);
     }
 
@@ -43,11 +49,22 @@ public class PaymentServiceImpl implements PaymentService {
     @Override
     @Transactional
     public Map<String, Object> confirmPayment(PaymentConfirmRequest request, Long authMemberId) {
-
         Payment payment = getValidPayment(request.orderId(), authMemberId);
         Map<String, Object> response = tossPaymentService.confirmPayment(request);
         ParsedTossApiResponse parsedResponse = ParsedTossApiResponse.fromResponse(response);
         updatePayment(payment, parsedResponse);
+
+        // Order 조회
+        var order = payment.getOrder();
+
+        // 주문 상태 및 일시 업데이트
+        order.updateOrderStatus(PaymentStatus.DONE.name());
+        order.updateCompletedAt(LocalDateTime.now());
+        order.updatePaidAt(payment.getCompletedAt());
+
+        // 주문 이력 업데이트
+        orderService.createOrderHistory(order, CreatedByType.MEMBER, authMemberId);
+
         return response;
     }
 

--- a/src/main/java/com/tutti/server/core/payment/application/TossPaymentService.java
+++ b/src/main/java/com/tutti/server/core/payment/application/TossPaymentService.java
@@ -70,7 +70,7 @@ public class TossPaymentService {
     private Map<String, Object> buildRequestBody(PaymentConfirmRequest request) {
         return Map.of(
                 "paymentKey", request.paymentKey(),
-                "orderId", request.orderId(),
+                "orderNumber", request.orderId(),
                 "amount", request.amount()
         );
     }

--- a/src/main/java/com/tutti/server/core/payment/payload/request/PaymentRequest.java
+++ b/src/main/java/com/tutti/server/core/payment/payload/request/PaymentRequest.java
@@ -7,17 +7,20 @@ import com.tutti.server.core.payment.domain.PaymentStatus;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 
+@Builder
 public record PaymentRequest(
 
         @NotNull(message = "주문 ID는 필수입니다.")
-        String orderId, // 요청을 orderId로 보내서 dto는 id로
+        String orderNumber, // 요청을 orderId로 보내서 dto는 id로
 
         @Min(value = 1, message = "결제 금액은 최소 1원 이상이어야 합니다.")
         int amount,
 
         @NotBlank(message = "주문명은 필수입니다.")
-        String orderName) {
+        String orderName
+) {
 
     // 요청이 들어왔을때 첫 결제가 생성됨.
     public static Payment toEntity(Order order, Member member, int amount, String orderName,


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #328 

---

### 🚀 어떤 기능을 구현했나요 ?
1. 주문 생성 API와 결제 생성 API 합치기
2. 뭔가 변동사항이 있음

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- Payment 쪽 바뀐 부분 집중해서 보시면 됩니다!
- 참고사항
1. PaymentApi : 여기 응답값 없어졌어요.
![image](https://github.com/user-attachments/assets/7f2b7cf7-5c29-4b3d-abaf-c48a8ef8a26f)

3. PaymentService : 여기 응답값 안 쓴다고 경고 메세지 떠요.
![image](https://github.com/user-attachments/assets/89a75ebe-df52-4cab-9dd5-edefbc407093)


### 📚 참고 자료, 할 말
저도 이제 주문 테스트 못함 ㅠ
