### PR TITLE
[BE] Feat: 리뷰 별점별 갯수 카운팅

### DIFF
--- a/src/main/java/com/tutti/server/core/review/api/ReviewApi.java
+++ b/src/main/java/com/tutti/server/core/review/api/ReviewApi.java
@@ -8,6 +8,7 @@ import com.tutti.server.core.review.application.SentimentService;
 import com.tutti.server.core.review.payload.request.ReviewCreateRequest;
 import com.tutti.server.core.review.payload.request.SentimentFeedbackRequest;
 import com.tutti.server.core.review.payload.request.SentimentRequest;
+import com.tutti.server.core.review.payload.response.ReviewCountPerStarResponse;
 import com.tutti.server.core.review.payload.response.ReviewDeleteResponse;
 import com.tutti.server.core.review.payload.response.ReviewDetailResponse;
 import com.tutti.server.core.review.payload.response.ReviewLikeResponse;
@@ -130,6 +131,15 @@ public class ReviewApi implements ReviewApiSpec {
             @PathVariable Long productId
     ) {
         ReviewRatingResponse response = reviewService.reviewRating(productId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @GetMapping("/{productId}/countStar")
+    public ResponseEntity<ReviewCountPerStarResponse> countStar(
+            @PathVariable Long productId
+    ) {
+        ReviewCountPerStarResponse response = reviewService.reviewCountPerStar(productId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/tutti/server/core/review/api/ReviewApiSpec.java
+++ b/src/main/java/com/tutti/server/core/review/api/ReviewApiSpec.java
@@ -4,6 +4,7 @@ import com.tutti.server.core.member.application.CustomUserDetails;
 import com.tutti.server.core.review.payload.request.ReviewCreateRequest;
 import com.tutti.server.core.review.payload.request.SentimentFeedbackRequest;
 import com.tutti.server.core.review.payload.request.SentimentRequest;
+import com.tutti.server.core.review.payload.response.ReviewCountPerStarResponse;
 import com.tutti.server.core.review.payload.response.ReviewDeleteResponse;
 import com.tutti.server.core.review.payload.response.ReviewDetailResponse;
 import com.tutti.server.core.review.payload.response.ReviewLikeResponse;
@@ -64,4 +65,7 @@ public interface ReviewApiSpec {
 
     @Operation(summary = "리뷰 별점 평균 API")
     ResponseEntity<ReviewRatingResponse> ratingAverage(Long productId);
+
+    @Operation(summary = "리뷰 점수별 리뷰 갯수")
+    ResponseEntity<ReviewCountPerStarResponse> countStar(Long productId);
 }

--- a/src/main/java/com/tutti/server/core/review/application/ReviewCountStarService.java
+++ b/src/main/java/com/tutti/server/core/review/application/ReviewCountStarService.java
@@ -1,0 +1,8 @@
+package com.tutti.server.core.review.application;
+
+import com.tutti.server.core.review.payload.response.ReviewCountPerStarResponse;
+
+public interface ReviewCountStarService {
+
+    ReviewCountPerStarResponse reviewCountPerStar(Long productId);
+}

--- a/src/main/java/com/tutti/server/core/review/application/ReviewCountStarServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/review/application/ReviewCountStarServiceImpl.java
@@ -16,14 +16,11 @@ public class ReviewCountStarServiceImpl implements ReviewCountStarService {
 
     @Override
     public ReviewCountPerStarResponse reviewCountPerStar(Long productId) {
-        List<Object[]> starCounts = reviewRepository.countStarGroupBy(productId);
+        List<Object[]> starCounts = reviewRepository.countStarGroupBy(productId); // 여기 런타임 오류 위험!
 
         RatingResponse stars = RatingResponseFactory.fromStarCounts(starCounts);
         long totalCount = RatingResponseFactory.calculateTotalCount(stars);
 
-        return ReviewCountPerStarResponse.builder()
-                .totalCount(totalCount)
-                .reviewRatings(stars)
-                .build();
+        return ReviewCountPerStarResponse.of(totalCount, stars);
     }
 }

--- a/src/main/java/com/tutti/server/core/review/application/ReviewCountStarServiceImpl.java
+++ b/src/main/java/com/tutti/server/core/review/application/ReviewCountStarServiceImpl.java
@@ -1,0 +1,29 @@
+package com.tutti.server.core.review.application;
+
+import com.tutti.server.core.review.infrastructure.ReviewRepository;
+import com.tutti.server.core.review.payload.response.RatingResponse;
+import com.tutti.server.core.review.payload.response.ReviewCountPerStarResponse;
+import com.tutti.server.core.review.utils.RatingResponseFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewCountStarServiceImpl implements ReviewCountStarService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public ReviewCountPerStarResponse reviewCountPerStar(Long productId) {
+        List<Object[]> starCounts = reviewRepository.countStarGroupBy(productId);
+
+        RatingResponse stars = RatingResponseFactory.fromStarCounts(starCounts);
+        long totalCount = RatingResponseFactory.calculateTotalCount(stars);
+
+        return ReviewCountPerStarResponse.builder()
+                .totalCount(totalCount)
+                .reviewRatings(stars)
+                .build();
+    }
+}

--- a/src/main/java/com/tutti/server/core/review/application/ReviewService.java
+++ b/src/main/java/com/tutti/server/core/review/application/ReviewService.java
@@ -1,6 +1,7 @@
 package com.tutti.server.core.review.application;
 
 import com.tutti.server.core.review.payload.request.ReviewCreateRequest;
+import com.tutti.server.core.review.payload.response.ReviewCountPerStarResponse;
 import com.tutti.server.core.review.payload.response.ReviewCreateResponse;
 import com.tutti.server.core.review.payload.response.ReviewDeleteResponse;
 import com.tutti.server.core.review.payload.response.ReviewDetailResponse;
@@ -22,6 +23,7 @@ public class ReviewService {
     private final ReviewDeleteService reviewDeleteService;
     private final ReviewLikeService reviewLikeService;
     private final ReviewRatingService reviewRatingService;
+    private final ReviewCountStarService reviewCountStarService;
 
     public ReviewCreateResponse createReview(ReviewCreateRequest request, Long memberId) {
         return reviewCreateService.createReview(request, memberId);
@@ -49,5 +51,9 @@ public class ReviewService {
 
     public ReviewRatingResponse reviewRating(Long productId) {
         return reviewRatingService.ratingAverage(productId);
+    }
+
+    public ReviewCountPerStarResponse reviewCountPerStar(Long productId) {
+        return reviewCountStarService.reviewCountPerStar(productId);
     }
 }

--- a/src/main/java/com/tutti/server/core/review/infrastructure/ReviewRepository.java
+++ b/src/main/java/com/tutti/server/core/review/infrastructure/ReviewRepository.java
@@ -117,4 +117,16 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // 리뷰의 평점을 합산하여 평균을 계산
     @Query("SELECT AVG(r.rating) FROM Review r WHERE r.productItem.product.id = :productId")
     Double findAverageRatingByProductId(Long productId);
+
+    // 리뷰의 별점별 갯수
+    @Query(value = """
+                SELECT FLOOR(r.rating) AS star, COUNT(*) AS count
+                FROM reviews r
+                JOIN product_items pi ON r.product_item_id = pi.id
+                JOIN products p ON pi.product_id = p.id
+                WHERE p.id = :productId
+                GROUP BY FLOOR(r.rating)
+                ORDER BY star DESC
+            """, nativeQuery = true)
+    List<Object[]> countStarGroupBy(@Param("productId") Long productId);
 }

--- a/src/main/java/com/tutti/server/core/review/payload/response/RatingResponse.java
+++ b/src/main/java/com/tutti/server/core/review/payload/response/RatingResponse.java
@@ -1,0 +1,17 @@
+package com.tutti.server.core.review.payload.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Builder;
+
+@Builder
+@JsonPropertyOrder({"5", "4", "3", "2", "1"})
+public record RatingResponse(
+        @JsonProperty("5") long fiveStar,
+        @JsonProperty("4") long fourStar,
+        @JsonProperty("3") long threeStar,
+        @JsonProperty("2") long twoStar,
+        @JsonProperty("1") long oneStar
+) {
+
+}

--- a/src/main/java/com/tutti/server/core/review/payload/response/ReviewCountPerStarResponse.java
+++ b/src/main/java/com/tutti/server/core/review/payload/response/ReviewCountPerStarResponse.java
@@ -1,0 +1,12 @@
+package com.tutti.server.core.review.payload.response;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewCountPerStarResponse(
+        Long totalCount,
+        RatingResponse reviewRatings
+) {
+
+}
+

--- a/src/main/java/com/tutti/server/core/review/payload/response/ReviewCountPerStarResponse.java
+++ b/src/main/java/com/tutti/server/core/review/payload/response/ReviewCountPerStarResponse.java
@@ -8,5 +8,11 @@ public record ReviewCountPerStarResponse(
         RatingResponse reviewRatings
 ) {
 
+    public static ReviewCountPerStarResponse of(Long totalCount, RatingResponse reviewRatings) {
+        return ReviewCountPerStarResponse.builder()
+                .totalCount(totalCount)
+                .reviewRatings(reviewRatings)
+                .build();
+    }
 }
 

--- a/src/main/java/com/tutti/server/core/review/utils/RatingResponseFactory.java
+++ b/src/main/java/com/tutti/server/core/review/utils/RatingResponseFactory.java
@@ -1,0 +1,41 @@
+package com.tutti.server.core.review.utils;
+
+import com.tutti.server.core.review.payload.response.RatingResponse;
+import java.util.List;
+
+public class RatingResponseFactory {
+
+    public static RatingResponse fromStarCounts(List<Object[]> starCounts) {
+        long one = 0L, two = 0L, three = 0L, four = 0L, five = 0L;
+
+        for (int i = starCounts.size() - 1; i >= 0; i--) {
+            Object[] row = starCounts.get(i);
+            int star = ((Number) row[0]).intValue();
+            long count = ((Number) row[1]).longValue();
+
+            switch (star) {
+                case 1 -> one = count;
+                case 2 -> two = count;
+                case 3 -> three = count;
+                case 4 -> four = count;
+                case 5 -> five = count;
+            }
+        }
+
+        return RatingResponse.builder()
+                .fiveStar(five)
+                .fourStar(four)
+                .threeStar(three)
+                .twoStar(two)
+                .oneStar(one)
+                .build();
+    }
+
+    public static long calculateTotalCount(RatingResponse ratingResponse) {
+        return ratingResponse.fiveStar()
+                + ratingResponse.fourStar()
+                + ratingResponse.threeStar()
+                + ratingResponse.twoStar()
+                + ratingResponse.oneStar();
+    }
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #371 

---

### 🚀 어떤 기능을 구현했나요 ?

- 리뷰의 별점별로 리뷰 개수를 카운팅 하는 기능입니다.

### 🔥 어떻게 해결했나요 ?
- 5 -> 4 -> 3 순으로 역순 정렬 하도록 리팩토링계획입니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말
현재는 1 -> 2 -> 3-> 오름차순으로 별점이 나오는데
5 -> 4 -> 3 순으로 나오록 리팩토링계획입니다.
프론트에서 오름차순, 내림차순 상관 없다고 해서 데이터를 사용하는데 문제는 없어보입니다.
개인 공부거리로 남겨놓겠습니다.