### PR TITLE
[BE] refactor: 상품 데이터에 태깅

### DIFF
--- a/src/main/java/com/tutti/server/core/product/payload/response/ProductItemResponse.java
+++ b/src/main/java/com/tutti/server/core/product/payload/response/ProductItemResponse.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tutti.server.core.product.domain.Product;
 import com.tutti.server.core.sku.domain.Sku;
 import com.tutti.server.core.store.domain.Store;
-import com.tutti.server.core.tag.domain.ProductTag;
+import com.tutti.server.core.tag.payload.response.ProductTagResponse;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 
@@ -23,7 +22,7 @@ public record ProductItemResponse(
         boolean adultOnly,
         int likes,
         boolean almostOutOfStock,
-        List<ProductTag> productTags,
+        List<ProductTagResponse> productTags,
 
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
@@ -35,7 +34,12 @@ public record ProductItemResponse(
     public static ProductItemResponse fromEntity(Product product,
             List<ProductOptionResponse> productOptionItems, Store store, Sku sku
     ) {
-        List<ProductTag> productTags = new ArrayList<>(product.getProductTags());
+        List<ProductTagResponse> tagResponses = product.getProductTags().stream()
+                .map(tag -> ProductTagResponse.builder()
+                        .tagId(tag.getId())
+                        .tagName(tag.getTag().getTagName())
+                        .build())
+                .toList();
 
         return ProductItemResponse.builder()
                 .productId(product.getId())
@@ -49,7 +53,7 @@ public record ProductItemResponse(
                 .adultOnly(product.isAdultOnly())
                 .likes(product.getLikeCount())
                 .almostOutOfStock(sku != null && sku.getStockQuantity() <= 10)
-                .productTags(productTags)
+                .productTags(tagResponses)
                 .createdAt(product.getCreatedAt())
                 .updatedAt(product.getUpdatedAt())
                 .build();

--- a/src/main/java/com/tutti/server/core/product/payload/response/ProductResponse.java
+++ b/src/main/java/com/tutti/server/core/product/payload/response/ProductResponse.java
@@ -4,9 +4,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tutti.server.core.product.domain.Product;
 import com.tutti.server.core.product.domain.ProductItem;
 import com.tutti.server.core.store.domain.Store;
-import com.tutti.server.core.tag.domain.ProductTag;
+import com.tutti.server.core.tag.payload.response.ProductTagResponse;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 
@@ -22,7 +21,7 @@ public record ProductResponse(
         int sellingPrice,
         boolean adultOnly,
         int likes,
-        List<ProductTag> productTags,
+        List<ProductTagResponse> productTags,
 
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
@@ -35,7 +34,12 @@ public record ProductResponse(
     public static ProductResponse fromEntity(Product product, ProductItem productItem,
             Store store
     ) {
-        List<ProductTag> productTags = new ArrayList<>(product.getProductTags());
+        List<ProductTagResponse> tagResponses = product.getProductTags().stream()
+                .map(tag -> ProductTagResponse.builder()
+                        .tagId(tag.getId())
+                        .tagName(tag.getTag().getTagName())
+                        .build())
+                .toList();
 
         return ProductResponse.builder()
                 .productId(product.getId())
@@ -47,7 +51,7 @@ public record ProductResponse(
                 .sellingPrice(productItem.getSellingPrice())
                 .adultOnly(product.isAdultOnly())
                 .likes(product.getLikeCount())
-                .productTags(productTags)
+                .productTags(tagResponses)
                 .createdAt(product.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/tutti/server/core/tag/domain/ProductTag.java
+++ b/src/main/java/com/tutti/server/core/tag/domain/ProductTag.java
@@ -1,5 +1,6 @@
 package com.tutti.server.core.tag.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tutti.server.core.product.domain.Product;
 import com.tutti.server.core.support.entity.BaseEntity;
 import jakarta.persistence.Entity;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductTag extends BaseEntity {
 
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "product_id")
     private Product product;

--- a/src/main/java/com/tutti/server/core/tag/payload/response/ProductTagResponse.java
+++ b/src/main/java/com/tutti/server/core/tag/payload/response/ProductTagResponse.java
@@ -1,0 +1,11 @@
+package com.tutti.server.core.tag.payload.response;
+
+import lombok.Builder;
+
+@Builder
+public record ProductTagResponse(
+        Long tagId,
+        String tagName
+) {
+
+}


### PR DESCRIPTION
<!-- 제목: [BE/FE/All] (기능 등) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

- resolves #451 

---

### 🚀 어떤 기능을 구현했나요 ?
 1. 상품 데이터에 태깅 
 2. Products <> Product_tags 양방향 참조로 인한 무한 루프 버그 해결
 - ProductTag 엔티티 Product 필드에 @JsonIgnore 어노테이션 추가 
 - ProductTagResponse DTO 추가: 상품 목록 조회 응답값 필드드 엔티티 리스트 대신 DTO로 필요한 데이터만 전달 
 3. 데이터 업로드

- 

### 🔥 어떻게 해결했나요 ?
- 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 

### 📚 참고 자료, 할 말

